### PR TITLE
WiFi/GSM status/signal sensors

### DIFF
--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -43,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 
 class G90AlarmPanel(AlarmControlPanelEntity):
 
-    def __init__(self, hass_data: object) -> None:
+    def __init__(self, hass_data: dict) -> None:
         self._attr_unique_id = hass_data['guid']
         self._attr_supported_features = (
             SUPPORT_ALARM_ARM_AWAY | SUPPORT_ALARM_ARM_HOME

--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -5,60 +5,47 @@ from homeassistant.core import HomeAssistant
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_DOOR,
-    DEVICE_CLASS_WINDOW,
-    DEVICE_CLASS_GAS,
-    DEVICE_CLASS_SMOKE,
-    DEVICE_CLASS_PROBLEM,
-    DEVICE_CLASS_VIBRATION,
-    DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_LOCK,
-    DEVICE_CLASS_CONNECTIVITY,
-    DEVICE_CLASS_COLD,
-    DEVICE_CLASS_PLUG,
-    DEVICE_CLASS_SOUND,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_OCCUPANCY,
+    BinarySensorDeviceClass,
 )
 
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from pyg90alarm.entities.sensor import G90SensorTypes
+from pyg90alarm.host_info import (G90HostInfoWifiStatus, G90HostInfoGsmStatus)
 from .const import DOMAIN
 import logging
 
 HASS_SENSOR_TYPES_MAPPING = {
-    G90SensorTypes.DOOR               : DEVICE_CLASS_DOOR,
-    G90SensorTypes.GLASS              : DEVICE_CLASS_WINDOW,
-    G90SensorTypes.GAS                : DEVICE_CLASS_GAS,
-    G90SensorTypes.SMOKE              : DEVICE_CLASS_SMOKE,
-    G90SensorTypes.SOS                : DEVICE_CLASS_PROBLEM,
-    G90SensorTypes.VIB                : DEVICE_CLASS_VIBRATION,
-    G90SensorTypes.WATER              : DEVICE_CLASS_MOISTURE,
-    G90SensorTypes.INFRARED           : DEVICE_CLASS_MOTION,
-    G90SensorTypes.IN_BEAM            : DEVICE_CLASS_MOTION,
-    G90SensorTypes.REMOTE             : DEVICE_CLASS_LOCK,
-    G90SensorTypes.RFID               : DEVICE_CLASS_LOCK,
-    G90SensorTypes.DOORBELL           : DEVICE_CLASS_OCCUPANCY,
-    G90SensorTypes.BUTTONID           : DEVICE_CLASS_LOCK,
-    G90SensorTypes.WATCH              : DEVICE_CLASS_OCCUPANCY,
-    G90SensorTypes.FINGER_LOCK        : DEVICE_CLASS_LOCK,
-    G90SensorTypes.SUBHOST            : DEVICE_CLASS_CONNECTIVITY,
-    G90SensorTypes.REMOTE_2_4G        : DEVICE_CLASS_LOCK,
-    G90SensorTypes.CORD_SENSOR        : DEVICE_CLASS_MOTION,
-    G90SensorTypes.SOCKET             : DEVICE_CLASS_PLUG,
-    G90SensorTypes.SIREN              : DEVICE_CLASS_SOUND,
-    G90SensorTypes.CURTAIN            : DEVICE_CLASS_WINDOW,
-    G90SensorTypes.SLIDINGWIN         : DEVICE_CLASS_WINDOW,
-    G90SensorTypes.AIRCON             : DEVICE_CLASS_COLD,
-    G90SensorTypes.TV                 : DEVICE_CLASS_CONNECTIVITY,
-    G90SensorTypes.SOCKET_2_4G        : DEVICE_CLASS_PLUG,
-    G90SensorTypes.SIREN_2_4G         : DEVICE_CLASS_SOUND,
-    G90SensorTypes.SWITCH_2_4G        : DEVICE_CLASS_POWER,
-    G90SensorTypes.TOUCH_SWITCH_2_4G  : DEVICE_CLASS_POWER,
-    G90SensorTypes.CURTAIN_2_4G       : DEVICE_CLASS_WINDOW,
-    G90SensorTypes.CORD_DEV           : DEVICE_CLASS_MOTION,
+    G90SensorTypes.DOOR: BinarySensorDeviceClass.DOOR,
+    G90SensorTypes.GLASS: BinarySensorDeviceClass.WINDOW,
+    G90SensorTypes.GAS: BinarySensorDeviceClass.GAS,
+    G90SensorTypes.SMOKE: BinarySensorDeviceClass.SMOKE,
+    G90SensorTypes.SOS: BinarySensorDeviceClass.PROBLEM,
+    G90SensorTypes.VIB: BinarySensorDeviceClass.VIBRATION,
+    G90SensorTypes.WATER: BinarySensorDeviceClass.MOISTURE,
+    G90SensorTypes.INFRARED: BinarySensorDeviceClass.MOTION,
+    G90SensorTypes.IN_BEAM: BinarySensorDeviceClass.MOTION,
+    G90SensorTypes.REMOTE: BinarySensorDeviceClass.LOCK,
+    G90SensorTypes.RFID: BinarySensorDeviceClass.LOCK,
+    G90SensorTypes.DOORBELL: BinarySensorDeviceClass.OCCUPANCY,
+    G90SensorTypes.BUTTONID: BinarySensorDeviceClass.LOCK,
+    G90SensorTypes.WATCH: BinarySensorDeviceClass.OCCUPANCY,
+    G90SensorTypes.FINGER_LOCK: BinarySensorDeviceClass.LOCK,
+    G90SensorTypes.SUBHOST: BinarySensorDeviceClass.CONNECTIVITY,
+    G90SensorTypes.REMOTE_2_4G: BinarySensorDeviceClass.LOCK,
+    G90SensorTypes.CORD_SENSOR: BinarySensorDeviceClass.MOTION,
+    G90SensorTypes.SOCKET: BinarySensorDeviceClass.PLUG,
+    G90SensorTypes.SIREN: BinarySensorDeviceClass.SOUND,
+    G90SensorTypes.CURTAIN: BinarySensorDeviceClass.WINDOW,
+    G90SensorTypes.SLIDINGWIN: BinarySensorDeviceClass.WINDOW,
+    G90SensorTypes.AIRCON: BinarySensorDeviceClass.COLD,
+    G90SensorTypes.TV: BinarySensorDeviceClass.CONNECTIVITY,
+    G90SensorTypes.SOCKET_2_4G: BinarySensorDeviceClass.PLUG,
+    G90SensorTypes.SIREN_2_4G: BinarySensorDeviceClass.SOUND,
+    G90SensorTypes.SWITCH_2_4G: BinarySensorDeviceClass.POWER,
+    G90SensorTypes.TOUCH_SWITCH_2_4G: BinarySensorDeviceClass.POWER,
+    G90SensorTypes.CURTAIN_2_4G: BinarySensorDeviceClass.WINDOW,
+    G90SensorTypes.CORD_DEV: BinarySensorDeviceClass.MOTION,
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,28 +54,29 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
                             async_add_entities: AddEntitiesCallback) -> None:
     """Set up a config entry."""
-    g90_client = hass.data[DOMAIN][entry.entry_id]['client']
-    g90_device = hass.data[DOMAIN][entry.entry_id]['device']
-    g90_guid = hass.data[DOMAIN][entry.entry_id]['guid']
     g90sensors = []
-    for sensor in await g90_client.sensors:
+    for sensor in await hass.data[DOMAIN][entry.entry_id]['client'].sensors:
         if sensor.enabled:
-            g90sensors.append(G90Sensor(sensor, g90_client, g90_device, g90_guid))
+            g90sensors.append(
+                G90BinarySensor(sensor, hass.data[DOMAIN][entry.entry_id])
+            )
+    g90sensors.append(G90WifiStatusSensor(hass.data[DOMAIN][entry.entry_id]))
+    g90sensors.append(G90GsmStatusSensor(hass.data[DOMAIN][entry.entry_id]))
     async_add_entities(g90sensors)
 
 
-class G90Sensor(BinarySensorEntity):
+class G90BinarySensor(BinarySensorEntity):
 
-    def __init__(self, sensor: object, g90_client: object, g90_device: object, g90_guid: str) -> None:
+    def __init__(self, sensor: object, hass_data: object) -> None:
         self._sensor = sensor
-        self._g90_client = g90_client
-        self._attr_unique_id = f'{g90_guid}_sensor_{sensor.index}'
+        self._attr_unique_id = f"{hass_data['guid']}_sensor_{sensor.index}"
         self._attr_name = sensor.name
         hass_sensor_type = HASS_SENSOR_TYPES_MAPPING.get(sensor.type, None)
         if hass_sensor_type:
             self._attr_device_class = hass_sensor_type
         sensor.state_callback = self.state_callback
-        self._attr_device_info = g90_device
+        self._attr_device_info = hass_data['device']
+        self._hass_data = hass_data
 
     def state_callback(self, value):
         _LOGGER.debug(f'{self.unique_id}: Received state callback: {value}')
@@ -99,3 +87,37 @@ class G90Sensor(BinarySensorEntity):
         val = self._sensor.occupancy
         _LOGGER.debug(f'{self.unique_id}: Providing state {val}')
         return val
+
+
+class G90WifiStatusSensor(BinarySensorEntity):
+
+    def __init__(self, hass_data: object) -> None:
+
+        self._attr_name = 'WiFi Status'
+        self._attr_unique_id = f"{hass_data['guid']}_sensor_wifi_status"
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._attr_device_info = hass_data['device']
+        self._hass_data = hass_data
+
+    @property
+    def is_on(self) -> bool:
+        # `host_info` of entry data is periodically updated by `G90AlarmPanel`
+        status = self._hass_data['host_info'].wifi_status
+        return status == G90HostInfoWifiStatus.OPERATIONAL
+
+
+class G90GsmStatusSensor(BinarySensorEntity):
+
+    def __init__(self, hass_data: object) -> None:
+
+        self._attr_name = 'GSM Status'
+        self._attr_unique_id = f"{hass_data['guid']}_sensor_gsm_status"
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._attr_device_info = hass_data['device']
+        self._hass_data = hass_data
+
+    @property
+    def is_on(self) -> bool:
+        # See above re: how the data is updated
+        status = self._hass_data['host_info'].gsm_status
+        return status == G90HostInfoGsmStatus.OPERATIONAL

--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 
 class G90BinarySensor(BinarySensorEntity):
 
-    def __init__(self, sensor: object, hass_data: object) -> None:
+    def __init__(self, sensor: object, hass_data: dict) -> None:
         self._sensor = sensor
         self._attr_unique_id = f"{hass_data['guid']}_sensor_{sensor.index}"
         self._attr_name = sensor.name
@@ -91,7 +91,7 @@ class G90BinarySensor(BinarySensorEntity):
 
 class G90WifiStatusSensor(BinarySensorEntity):
 
-    def __init__(self, hass_data: object) -> None:
+    def __init__(self, hass_data: dict) -> None:
 
         self._attr_name = 'WiFi Status'
         self._attr_unique_id = f"{hass_data['guid']}_sensor_wifi_status"
@@ -108,7 +108,7 @@ class G90WifiStatusSensor(BinarySensorEntity):
 
 class G90GsmStatusSensor(BinarySensorEntity):
 
-    def __init__(self, hass_data: object) -> None:
+    def __init__(self, hass_data: dict) -> None:
 
         self._attr_name = 'GSM Status'
         self._attr_unique_id = f"{hass_data['guid']}_sensor_gsm_status"

--- a/custom_components/gs_alarm/config_flow.py
+++ b/custom_components/gs_alarm/config_flow.py
@@ -42,7 +42,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_custom_host(None)
         # FIXME: Handle multiple devices
         for device in devices:
-            res = self.async_create_entry(title=DOMAIN, data={'ip_addr': device['host']})
+            res = self.async_create_entry(
+                title=DOMAIN, data={'ip_addr': device['host']}
+            )
         return res
 
     async def async_step_user(
@@ -66,7 +68,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title=DOMAIN, data=user_input)
 
         return self.async_show_form(
-            step_id="custom_host", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="custom_host", data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors
         )
 
     @staticmethod
@@ -91,7 +94,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(
                         "sms_alert_when_armed",
-                        default=self.config_entry.options.get("sms_alert_when_armed"),
+                        default=self.config_entry.options.get(
+                            "sms_alert_when_armed"
+                        ),
                     ): bool
                 }
             ),

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/hostcc/hass-gs-alarm/README.md",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
-    "pyg90alarm==1.5.0"
+    "pyg90alarm==1.5.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/custom_components/gs_alarm/sensor.py
+++ b/custom_components/gs_alarm/sensor.py
@@ -32,7 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 
 class G90BaseSensor(SensorEntity):
 
-    def __init__(self, hass_data: object) -> None:
+    def __init__(self, hass_data: dict) -> None:
         self._hass_data = hass_data
         self._attr_device_info = hass_data['device']
 

--- a/custom_components/gs_alarm/sensor.py
+++ b/custom_components/gs_alarm/sensor.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    PERCENTAGE,
+)
+
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
+                            async_add_entities: AddEntitiesCallback) -> None:
+    """Set up a config entry."""
+    g90sensors = [
+        G90WifiSignal(hass.data[DOMAIN][entry.entry_id]),
+        G90GsmSignal(hass.data[DOMAIN][entry.entry_id]),
+    ]
+    async_add_entities(g90sensors)
+
+
+class G90BaseSensor(SensorEntity):
+
+    def __init__(self, hass_data: object) -> None:
+        self._hass_data = hass_data
+        self._attr_device_info = hass_data['device']
+
+
+class G90WifiSignal(G90BaseSensor):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._attr_name = 'WiFi Signal'
+        self._attr_unique_id = f"{self._hass_data['guid']}_sensor_wifi_signal"
+        self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    async def async_update(self):
+        # `host_info` of entry data is periodically updated by `G90AlarmPanel`
+        host_info = self._hass_data['host_info']
+        self._attr_native_value = host_info.wifi_signal_level
+
+
+class G90GsmSignal(G90BaseSensor):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._attr_name = 'GSM Signal'
+        self._attr_unique_id = f"{self._hass_data['guid']}_sensor_gsm_signal"
+        self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    async def async_update(self):
+        # See above re: how the data is updated
+        host_info = self._hass_data['host_info']
+        self._attr_native_value = host_info.gsm_signal_level

--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -13,23 +13,25 @@ from .const import DOMAIN
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
                             async_add_entities: AddEntitiesCallback) -> None:
     """Set up a config entry."""
-    g90_client = hass.data[DOMAIN][entry.entry_id]['client']
-    g90_device = hass.data[DOMAIN][entry.entry_id]['device']
-    g90_guid = hass.data[DOMAIN][entry.entry_id]['guid']
     g90switches = []
-    for device in await g90_client.devices:
-        g90switches.append(G90Switch(device, g90_device, g90_guid))
+    for device in await hass.data[DOMAIN][entry.entry_id]['client'].devices:
+        g90switches.append(
+            G90Switch(device, hass.data[DOMAIN][entry.entry_id])
+        )
     async_add_entities(g90switches)
 
 
 class G90Switch(SwitchEntity):
 
-    def __init__(self, device: object, g90_device: object, g90_guid: str) -> None:
+    def __init__(self, device: object, hass_data: dict) -> None:
         self._device = device
         self._state = False
-        self._attr_unique_id = f'{g90_guid}_switch_{device.index}_{device.subindex + 1}'
+        self._attr_unique_id = (
+            f"{hass_data['guid']}_switch_{device.index}_{device.subindex + 1}"
+        )
         self._attr_name = device.name
-        self._attr_device_info = g90_device
+        self._attr_device_info = hass_data['device']
+        self._hass_data = hass_data
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
* Updated version of `pyg90alarm` dependency
* `G90Sensor` class renamed to `G90BinarySensor` to avoid collisions with regular (not binary) sensors
* Entry data now has `host_info` member that will periodically be updated by `G90AlarmPanel.asybc_update()` so sensors could use the data w/o duplicate access to `host_info` property of `G90Alarm`, which issues a device call internally
* Added `G90WifiStatusSensor`, `G90GsmStatusSensor`, `G90WifiSignal`, `G90GsmSignal` sensor classes, those represent WiFi/GSM connection   status and WiFi/GSM signal level, respectively
* `G90AlarmPanel`, `G90BinarySensor` constructors now receive only entry data as the argument, so they can access any member of the data dictionary then need, as well update a member if functionality requires that (see above for WiFi/GSM sensors as the example)
* `binary_sensor` platform now uses   `BinarySensor.BinarySensorDeviceClass` to map to supported device classes, as `DEVICE_CLASS_*` constants are deprecated now
* Linting fixes