### PR TITLE
Prefix integration domain to WiFi/GSM signal/connectivity sensors

### DIFF
--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -93,7 +93,7 @@ class G90WifiStatusSensor(BinarySensorEntity):
 
     def __init__(self, hass_data: dict) -> None:
 
-        self._attr_name = 'WiFi Status'
+        self._attr_name = f'{DOMAIN}: WiFi Status'
         self._attr_unique_id = f"{hass_data['guid']}_sensor_wifi_status"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
         self._attr_device_info = hass_data['device']
@@ -110,7 +110,7 @@ class G90GsmStatusSensor(BinarySensorEntity):
 
     def __init__(self, hass_data: dict) -> None:
 
-        self._attr_name = 'GSM Status'
+        self._attr_name = f'{DOMAIN}: GSM Status'
         self._attr_unique_id = f"{hass_data['guid']}_sensor_gsm_status"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
         self._attr_device_info = hass_data['device']

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/hostcc/hass-gs-alarm/README.md",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
-    "pyg90alarm==1.5.1"
+    "pyg90alarm==1.5.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/custom_components/gs_alarm/sensor.py
+++ b/custom_components/gs_alarm/sensor.py
@@ -41,7 +41,7 @@ class G90WifiSignal(G90BaseSensor):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._attr_name = 'WiFi Signal'
+        self._attr_name = f'{DOMAIN}: WiFi Signal'
         self._attr_unique_id = f"{self._hass_data['guid']}_sensor_wifi_signal"
         self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
         self._attr_native_unit_of_measurement = PERCENTAGE
@@ -57,7 +57,7 @@ class G90GsmSignal(G90BaseSensor):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._attr_name = 'GSM Signal'
+        self._attr_name = f'{DOMAIN}: GSM Signal'
         self._attr_unique_id = f"{self._hass_data['guid']}_sensor_gsm_signal"
         self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
         self._attr_native_unit_of_measurement = PERCENTAGE


### PR DESCRIPTION
* Updated version of `pyg90alarm` dependency
* Use integration domain (`gs_alarm`) as the prefix to the names of   WiFi/GSM signal level/connectivity sensors to avoid them being   possible duplicate to other integrations, since such names are pretty common