### PR TITLE
`pyg90alarm` version update for doorbell support

### DIFF
--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/hostcc/hass-gs-alarm/README.md",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
-    "pyg90alarm==1.5.2"
+    "pyg90alarm==1.6.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
   "name": "Golden Security Alarm",
-  "render_readme": true,
-  "domains": ["gs_alarm"]
+  "render_readme": true
 }


### PR DESCRIPTION
* Updated version of `pyg90alarm` dependency for doorbell support
* HACS manifest: removed unsupported domain entity