### PR TITLE
Support enabling/disabling sensors on `Configure` tab. Test suite

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check the code with hassfest
         uses: home-assistant/actions/hassfest@master
 
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check the code with hacs
         uses: "hacs/action@main"
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,9 +55,7 @@ jobs:
           python -m pip install --upgrade setuptools pip tox virtualenv coverage
       - name: Run the tests
         run: tox -e ${{ matrix.toxenv }}
-      - name: Combine Coverage reports
-        run: coverage combine
-      - name: Generage Coverage combined XML report
+      - name: Generage Coverage XML report
         run: coverage xml
       - name: Determine package version
         id: package-version

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,7 +52,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install testing tools
         run: >-
-          python -m pip install --upgrade setuptools pip tox virtualenv coverage
+          python -m pip install --upgrade setuptools_scm pip tox virtualenv coverage
       - name: Run the tests
         run: tox -e ${{ matrix.toxenv }}
       - name: Generage Coverage XML report
@@ -60,7 +60,7 @@ jobs:
       - name: Determine package version
         id: package-version
         run: |
-          package_version=`cat version.txt`
+          package_version=`python -m setuptools_scm`
           echo "VALUE=$package_version" >> $GITHUB_OUTPUT
       - name: SonarCloud scanning
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Determine package version
         id: package-version
         run: |
-          package_version=`python3 setup.py --version`
+          package_version=`cat version.txt`
           echo "VALUE=$package_version" >> $GITHUB_OUTPUT
       - name: SonarCloud scanning
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,3 +26,53 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: integration
+
+  tests:
+    name: Tests
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: '3.9'
+            toxenv: py
+          - os: ubuntu-latest
+            python: '3.10'
+            toxenv: py
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+        with:
+          # Disable shallow clone for Sonar scanner, as it needs access to the
+          # history
+          fetch-depth: 0
+      - name: Set Python up
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install testing tools
+        run: >-
+          python -m pip install --upgrade setuptools pip tox virtualenv coverage
+      - name: Run the tests
+        run: tox -e ${{ matrix.toxenv }}
+      - name: Combine Coverage reports
+        run: coverage combine
+      - name: Generage Coverage combined XML report
+        run: coverage xml
+      - name: Determine package version
+        id: package-version
+        run: |
+          package_version=`python3 setup.py --version`
+          echo "VALUE=$package_version" >> $GITHUB_OUTPUT
+      - name: SonarCloud scanning
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          # yamllint disable rule:line-length
+          args: >-
+            -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
+            -Dsonar.organization=${{ github.repository_owner }}
+            -Dsonar.projectVersion=${{ steps.package-version.outputs.VALUE }}
+          # yamllint enable rule:line-length

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ SMS messages if you enabled those in mobile application) to be sent.
 
 ## Specifics
 
-* The integration doesn't manage settings for the alarm panel, including
-  adding/removing sensors. You will still need the mobile application for that
+* The integration doesn't manage most of settings for the alarm panel, including
+  adding/removing sensors - you can only enable/disable sensors/realy. For the
+  rest you will still need the mobile application
 * No cloud or Internet connectivity required in case of local setup (Home
   Assistant in the same local network as the alarm panel)
 * Changes in alarm panel with regards to sensors and switches require the

--- a/custom_components/gs_alarm/__init__.py
+++ b/custom_components/gs_alarm/__init__.py
@@ -38,11 +38,9 @@ async def _enable_disable_sensors(g90_client, disabled_sensors):
 async def options_update_listener(hass, entry):
     """ Handle options update. """
     g90_client = hass.data[DOMAIN][entry.entry_id]['client']
-    g90_client.sms_alert_when_armed = entry.options.get(
-        'sms_alert_when_armed', False
-    )
+    g90_client.sms_alert_when_armed = entry.options['sms_alert_when_armed']
     await _enable_disable_sensors(
-        g90_client, entry.options.get('disabled_sensors')
+        g90_client, entry.options['disabled_sensors']
     )
 
 
@@ -73,8 +71,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await g90_client.listen_device_notifications()
 
     entry.async_on_unload(entry.add_update_listener(options_update_listener))
-    # Force setting options upon entry added
-    await options_update_listener(hass, entry)
 
     return True
 

--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -1,4 +1,8 @@
+"""
+tbd
+"""
 from __future__ import annotations
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -19,10 +23,10 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
 )
 
-from .const import DOMAIN
 from pyg90alarm.const import G90ArmDisarmTypes
 
-import logging
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -42,7 +46,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 
 
 class G90AlarmPanel(AlarmControlPanelEntity):
-
+    """
+    tbd
+    """
     def __init__(self, hass_data: dict) -> None:
         self._attr_unique_id = hass_data['guid']
         self._attr_supported_features = (
@@ -55,6 +61,9 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         self._hass_data['client'].armdisarm_callback = self.armdisarm_callback
 
     async def add_to_platform_finish(self) -> None:
+        """
+        tbd
+        """
         # Read the state of the alarm panel upon entry is added to the
         # platform, but before its state is persisted. This helps HomeAssistant
         # to reflect the panel state right upon startup, not delaying to next
@@ -63,35 +72,45 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         await super().add_to_platform_finish()
 
     def armdisarm_callback(self, state):
+        """
+        tbd
+        """
         _LOGGER.debug('Received arm/disarm callback: %s', state)
         self._state = STATE_MAPPING[state]
         # Schedule updating HA since the panel state has changed
         self.schedule_update_ha_state()
 
     async def async_update(self):
+        """
+        tbd
+        """
         _LOGGER.debug('Updating state')
-        host_status = await self._hass_data['client'].host_status
+
+        host_status = await self._hass_data['client'].get_host_status()
         host_state = host_status.host_status
         self._state = STATE_MAPPING[host_state]
         # Store alarm panel information (GSM/WiFi status/signal level etc.) so
         # a sensor could use the data w/o duplicate access to `host_info`
         # property of `G90Alarm`, which issues a device call internally
         self._hass_data['host_info'] = (
-            await self._hass_data['client'].host_info
+            await self._hass_data['client'].get_host_info()
         )
 
     @property
     def state(self):
+        """
+        tbd
+        """
         return self._state
 
-    async def async_alarm_disarm(self, code: str | None = None) -> None:
+    async def async_alarm_disarm(self, _code: str | None = None) -> None:
         """Send disarm command."""
         await self._hass_data['client'].disarm()
 
-    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+    async def async_alarm_arm_home(self, _code: str | None = None) -> None:
         """Send arm home command."""
         await self._hass_data['client'].arm_home()
 
-    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+    async def async_alarm_arm_away(self, _code: str | None = None) -> None:
         """Send arm away command."""
         await self._hass_data['client'].arm_away()

--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -1,4 +1,8 @@
+"""
+tbd
+"""
 from __future__ import annotations
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,7 +17,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyg90alarm.entities.sensor import G90SensorTypes
 from pyg90alarm.host_info import (G90HostInfoWifiStatus, G90HostInfoGsmStatus)
 from .const import DOMAIN
-import logging
 
 HASS_SENSOR_TYPES_MAPPING = {
     G90SensorTypes.DOOR: BinarySensorDeviceClass.DOOR,
@@ -55,7 +58,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
                             async_add_entities: AddEntitiesCallback) -> None:
     """Set up a config entry."""
     g90sensors = []
-    for sensor in await hass.data[DOMAIN][entry.entry_id]['client'].sensors:
+    for sensor in (
+        await hass.data[DOMAIN][entry.entry_id]['client'].get_sensors()
+    ):
         if sensor.enabled:
             g90sensors.append(
                 G90BinarySensor(sensor, hass.data[DOMAIN][entry.entry_id])
@@ -66,7 +71,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 
 
 class G90BinarySensor(BinarySensorEntity):
-
+    """
+    tbd
+    """
     def __init__(self, sensor: object, hass_data: dict) -> None:
         self._sensor = sensor
         self._attr_unique_id = f"{hass_data['guid']}_sensor_{sensor.index}"
@@ -79,18 +86,27 @@ class G90BinarySensor(BinarySensorEntity):
         self._hass_data = hass_data
 
     def state_callback(self, value):
-        _LOGGER.debug(f'{self.unique_id}: Received state callback: {value}')
+        """
+        tbd
+        """
+        _LOGGER.debug('%s: Received state callback: %s', self.unique_id, value)
         self.schedule_update_ha_state()
 
     @property
     def is_on(self) -> bool:
+        """
+        tbd
+        """
         val = self._sensor.occupancy
-        _LOGGER.debug(f'{self.unique_id}: Providing state {val}')
+        _LOGGER.debug('%s: Providing state %s', self.unique_id, val)
         return val
 
 
+# pylint:disable=too-few-public-methods
 class G90WifiStatusSensor(BinarySensorEntity):
-
+    """
+    tbd
+    """
     def __init__(self, hass_data: dict) -> None:
 
         self._attr_name = f'{DOMAIN}: WiFi Status'
@@ -101,13 +117,19 @@ class G90WifiStatusSensor(BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
+        """
+        tbd
+        """
         # `host_info` of entry data is periodically updated by `G90AlarmPanel`
         status = self._hass_data['host_info'].wifi_status
         return status == G90HostInfoWifiStatus.OPERATIONAL
 
 
+# pylint:disable=too-few-public-methods
 class G90GsmStatusSensor(BinarySensorEntity):
-
+    """
+    tbd
+    """
     def __init__(self, hass_data: dict) -> None:
 
         self._attr_name = f'{DOMAIN}: GSM Status'
@@ -118,6 +140,9 @@ class G90GsmStatusSensor(BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
+        """
+        tbd
+        """
         # See above re: how the data is updated
         status = self._hass_data['host_info'].gsm_status
         return status == G90HostInfoGsmStatus.OPERATIONAL

--- a/custom_components/gs_alarm/config_flow.py
+++ b/custom_components/gs_alarm/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for gs_alarm."""
 
 from __future__ import annotations
+import logging
 
 from typing import Any
 
@@ -9,12 +10,15 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.core import callback
-
-from .const import DOMAIN
-
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectOptionDict,
+)
 from pyg90alarm import G90Alarm
 
-import logging
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +37,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
+        """ tbd """
         if user_input is None:
             self._set_confirm_only()
             return self.async_show_form(step_id="confirm")
@@ -40,7 +45,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         devices = await self.hass.async_create_task(G90Alarm.discover())
         if not devices:
             return await self.async_step_custom_host(None)
-        # FIXME: Handle multiple devices
+        # Need to extend to handle multiple devices
         for device in devices:
             res = self.async_create_entry(
                 title=DOMAIN, data={'ip_addr': device['host']}
@@ -48,7 +53,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return res
 
     async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
+        self, _user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
         return await self.async_step_confirm(None)
@@ -56,6 +61,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_custom_host(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
+        """ tbd """
         if user_input is None:
             return self.async_show_form(
                 step_id="custom_host", data_schema=STEP_USER_DATA_SCHEMA
@@ -63,7 +69,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if not user_input.get('ip_addr', None):
-            errors['base'] = 'ip_addr_required'
+            errors['ip_addr'] = 'ip_addr_required'
         else:
             return self.async_create_entry(title=DOMAIN, data=user_input)
 
@@ -75,29 +81,76 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
+        """ tbd """
         return OptionsFlowHandler(config_entry)
 
 
+# pylint:disable=too-few-public-methods
 class OptionsFlowHandler(config_entries.OptionsFlow):
+    """ tbd """
     def __init__(self, config_entry):
         """ Initialize options flow. """
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """ Manage the options. """
+        g90_client = (
+            self.hass.data[DOMAIN]
+            .get(self.config_entry.entry_id, {})
+            .get('client', None)
+        )
+        schema = {
+            vol.Required(
+                "sms_alert_when_armed",
+                default=self.config_entry.options.get(
+                    "sms_alert_when_armed", False
+                ),
+            ): BooleanSelector(),
+        }
+
+        disabled_sensors = []
+        all_sensors = []
+        sensors_unsupported = []
+        if g90_client:
+            g90_sensors = await g90_client.get_sensors()
+            all_sensors = [
+                SelectOptionDict(label=x.name, value=str(x.index))
+                for x in g90_sensors
+            ]
+            disabled_sensors = [
+                str(x.index) for x in g90_sensors if not x.enabled
+            ]
+            sensors_unsupported = [
+                str(x.index) for x in g90_sensors
+                if not x.supports_enable_disable
+            ]
+            schema.update({
+                vol.Optional(
+                    "disabled_sensors",
+                    default=disabled_sensors
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=all_sensors,
+                        multiple=True,
+                    )
+                ),
+            })
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="init",
+                data_schema=vol.Schema(schema)
+            )
+
+        errors = {}
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            if sensors_unsupported in user_input.get('disabled_sensors', []):
+                errors['disabled_sensors'] = 'sensor_no_enable_disable_support'
+            else:
+                return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        "sms_alert_when_armed",
-                        default=self.config_entry.options.get(
-                            "sms_alert_when_armed"
-                        ),
-                    ): bool
-                }
-            ),
+            data_schema=vol.Schema(schema),
+            errors=errors
         )

--- a/custom_components/gs_alarm/config_flow.py
+++ b/custom_components/gs_alarm/config_flow.py
@@ -1,4 +1,6 @@
-"""Config flow for gs_alarm."""
+"""
+Config flow for `gs_alarm` integrarion.
+"""
 
 from __future__ import annotations
 import logging
@@ -24,29 +26,35 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required("ip_addr"): str,
+        vol.Required("ip_addr", default=False): str,
     }
 )
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for gs_alarm."""
-
+    """
+    Handles the config flow for `gs_alarm` integration.
+    """
     VERSION = 1
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """ tbd """
+        """
+        Handles discovering devices upon user confirmation.
+        """
         if user_input is None:
             self._set_confirm_only()
             return self.async_show_form(step_id="confirm")
 
         devices = await self.hass.async_create_task(G90Alarm.discover())
         _LOGGER.debug('Discovered devices: %s', devices)
+        # No devices discovered, present form for manual hostname/IP entry
         if not devices:
             return await self.async_step_custom_host(None)
-        # Need to extend to handle multiple devices
+
+        # Instantiate the integration for discovered devices
+        # Need to properly handle the result for multiple devices
         for device in devices:
             res = self.async_create_entry(
                 title=DOMAIN, data={'ip_addr': device['host']}
@@ -56,24 +64,30 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, _user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
+        """
+        Handles the initial step.
+        """
         return await self.async_step_confirm(None)
 
     async def async_step_custom_host(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """ tbd """
+        """
+        Handles adding integration with manual hostname/IP specified.
+        """
         if user_input is None:
             return self.async_show_form(
                 step_id="custom_host", data_schema=STEP_USER_DATA_SCHEMA
             )
         errors = {}
 
+        # Register the integration when hostname/IP is provided
         if not user_input.get('ip_addr', None):
             errors['ip_addr'] = 'ip_addr_required'
         else:
             return self.async_create_entry(title=DOMAIN, data=user_input)
 
+        # Hostname/IP address is required
         return self.async_show_form(
             step_id="custom_host", data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors
@@ -82,24 +96,34 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        """ tbd """
+        """
+        Instantiates options flow handler.
+        """
         return OptionsFlowHandler(config_entry)
 
 
 # pylint:disable=too-few-public-methods
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    """ tbd """
+    """
+    Handle options (configure) flows.
+    """
     def __init__(self, config_entry):
-        """ Initialize options flow. """
+        """
+        Initialize options flow.
+        """
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
-        """ Manage the options. """
+        """
+        Manage the options.
+        """
+        # Attempt to retrieve `G90Alarm()` instance from integration data
         g90_client = (
             self.hass.data[DOMAIN]
             .get(self.config_entry.entry_id, {})
             .get('client', None)
         )
+
         schema = {
             vol.Required(
                 "sms_alert_when_armed",
@@ -109,9 +133,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             ): BooleanSelector(),
         }
 
-        disabled_sensors = []
-        all_sensors = []
+        # `G90Alarm` instance might be missing, for example if integration has
+        # failed to load, not configuration is possible then for
+        # enabling/disabling the sensors
         if g90_client:
+            # Retrieve all sensors support enabling/disabling
             g90_sensors = await g90_client.get_sensors()
             all_sensors = [
                 SelectOptionDict(label=x.name, value=str(x.index))
@@ -121,10 +147,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             _LOGGER.debug(
                 'configure: all sensor entries for selector: %s', all_sensors
             )
+            # Determine currently sensors currently disabled, out of those
+            # supports altering the state.
+            # NOTE: If sensor doesn't support enabling/disabling thru
+            # `pyg90alarm` it will not be shown on the form, thus requiring
+            # mobile application to be managed
             disabled_sensors = [
                 str(x.index) for x in g90_sensors if not x.enabled
             ]
             _LOGGER.debug('configure: disabled sensors: %s', disabled_sensors)
+            # Add form element
             schema.update({
                 vol.Optional(
                     "disabled_sensors",
@@ -137,18 +169,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ),
             })
 
+        # Present the form back if no user input
         if user_input is None:
             return self.async_show_form(
                 step_id="init",
                 data_schema=vol.Schema(schema)
             )
 
-        errors = {}
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema(schema),
-            errors=errors
-        )
+        # (Re)create the integration entry, that will fetch the options and
+        # adjust its configuration
+        return self.async_create_entry(title="", data=user_input)

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -3,7 +3,7 @@
   "name": "Golden Security Alarm",
   "version": "0.0.0",
   "config_flow": true,
-  "documentation": "https://github.com/hostcc/hass-gs-alarm/README.md",
+  "documentation": "https://github.com/hostcc/hass-gs-alarm/blob/master/README.md",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
     "pyg90alarm==1.8.0"

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/hostcc/hass-gs-alarm/README.md",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
-    "pyg90alarm==1.6.0"
+    "pyg90alarm==1.8.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/custom_components/gs_alarm/sensor.py
+++ b/custom_components/gs_alarm/sensor.py
@@ -1,4 +1,8 @@
+"""
+tbd
+"""
 from __future__ import annotations
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -15,7 +19,6 @@ from homeassistant.const import (
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-import logging
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,15 +33,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
     async_add_entities(g90sensors)
 
 
+# pylint:disable=too-few-public-methods
 class G90BaseSensor(SensorEntity):
-
+    """
+    tbd
+    """
     def __init__(self, hass_data: dict) -> None:
         self._hass_data = hass_data
         self._attr_device_info = hass_data['device']
+        self._attr_native_value = None
+
+    async def async_update(self):
+        """
+        tbd
+        """
+        _LOGGER.debug('Updating state')
 
 
+# pylint:disable=too-few-public-methods
 class G90WifiSignal(G90BaseSensor):
-
+    """
+    tbd
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._attr_name = f'{DOMAIN}: WiFi Signal'
@@ -48,13 +64,19 @@ class G90WifiSignal(G90BaseSensor):
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
     async def async_update(self):
+        """
+        tbd
+        """
+        await super().async_update()
         # `host_info` of entry data is periodically updated by `G90AlarmPanel`
         host_info = self._hass_data['host_info']
         self._attr_native_value = host_info.wifi_signal_level
 
 
 class G90GsmSignal(G90BaseSensor):
-
+    """
+    tbd
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._attr_name = f'{DOMAIN}: GSM Signal'
@@ -64,6 +86,10 @@ class G90GsmSignal(G90BaseSensor):
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
     async def async_update(self):
+        """
+        tbd
+        """
+        await super().async_update()
         # See above re: how the data is updated
         host_info = self._hass_data['host_info']
         self._attr_native_value = host_info.gsm_signal_level

--- a/custom_components/gs_alarm/strings.json
+++ b/custom_components/gs_alarm/strings.json
@@ -20,7 +20,8 @@
     "step": {
       "init": {
         "data": {
-          "sms_alert_when_armed": "Configure SMS alerts only when device is armed"
+          "sms_alert_when_armed": "SMS alerts only when device is armed",
+          "disabled_sensors": "Disabled sensors"
         }
       }
     }

--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -1,4 +1,8 @@
+"""
+tbd
+"""
 from __future__ import annotations
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -6,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from typing import Any
 from .const import DOMAIN
 
 
@@ -14,7 +17,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
                             async_add_entities: AddEntitiesCallback) -> None:
     """Set up a config entry."""
     g90switches = []
-    for device in await hass.data[DOMAIN][entry.entry_id]['client'].devices:
+    for device in await (
+        hass.data[DOMAIN][entry.entry_id]['client'].get_devices()
+    ):
         g90switches.append(
             G90Switch(device, hass.data[DOMAIN][entry.entry_id])
         )
@@ -22,7 +27,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 
 
 class G90Switch(SwitchEntity):
-
+    """
+    tbd
+    """
     def __init__(self, device: object, hass_data: dict) -> None:
         self._device = device
         self._state = False
@@ -35,12 +42,21 @@ class G90Switch(SwitchEntity):
 
     @property
     def is_on(self) -> bool:
+        """
+        tbd
+        """
         return self._state
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **_kwargs: Any) -> None:
+        """
+        tbd
+        """
         await self._device.turn_on()
         self._state = True
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """
+        tbd
+        """
         await self._device.turn_off()
         self._state = False

--- a/custom_components/gs_alarm/translations/en.json
+++ b/custom_components/gs_alarm/translations/en.json
@@ -20,7 +20,8 @@
         "step": {
             "init": {
                 "data": {
-                    "sms_alert_when_armed": "Configure SMS alerts only when device is armed"
+                    "sms_alert_when_armed": "SMS alerts only when device is armed",
+                    "disabled_sensors": "Disabled sensors"
                 }
             }
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
-write_to = "version.txt"
 
 [tool.pytest.ini_options]
 log_cli = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=43.0.0", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"
+write_to = "version.txt"
+
+[tool.pytest.ini_options]
+log_cli = 1
+log_cli_level = "error"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@ sonar.python.version=3.9, 3.10
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.pylint.reportPaths=pylint.txt
 sonar.python.flake8.reportPaths=flake8.txt
-sonar.coverage.exclusions=tests/**,docs/**,setup.py
+sonar.coverage.exclusions=tests/**,**/*.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.python.version=3.9, 3.10
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.pylint.reportPaths=pylint.txt
+sonar.python.flake8.reportPaths=flake8.txt
+sonar.coverage.exclusions=tests/**,docs/**,setup.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,123 @@
+"""
+tbd
+"""
+from unittest.mock import patch, AsyncMock, PropertyMock
 import pytest
 
+import pyg90alarm
+
+
 @pytest.fixture(autouse=True)
+# pylint: disable=unused-argument
 def auto_enable_custom_integrations(enable_custom_integrations):
+    """
+    tbd
+    """
     yield
+
+
+def pytest_configure(config):
+    """
+    tbd
+    """
+    config.addinivalue_line("markers", "g90discovery")
+
+
+@pytest.fixture
+def mock_g90alarm(request):
+    """
+    tbd
+    """
+    with (
+        patch('custom_components.gs_alarm.G90Alarm', autospec=True) as mock,
+        patch(
+            'custom_components.gs_alarm.config_flow.G90Alarm.discover'
+        ) as mock_discover,
+    ):
+        mock_discover.return_value = (
+            getattr(
+                request.node
+                .get_closest_marker('g90discovery'),
+                'kwargs', {}
+            ).get('result', [])
+        )
+
+        mock.return_value.get_host_info = AsyncMock(
+            return_value=pyg90alarm.alarm.G90HostInfo(
+                host_guid='Dummy',
+                product_name='Dummy product',
+                wifi_protocol_version='1.0-test',
+                cloud_protocol_version='1.1-test',
+                mcu_hw_version='1.0-test',
+                wifi_hw_version='1.0-test',
+                gsm_status_data=0,
+                wifi_status_data=0,
+                reserved1=None,
+                reserved2=None,
+                band_frequency=None,
+                gsm_signal_level=100,
+                wifi_signal_level=100,
+            )
+        )
+
+        mock.return_value.get_host_status = AsyncMock(
+            return_value=pyg90alarm.alarm.G90HostStatus(
+                host_status=pyg90alarm.alarm.G90ArmDisarmTypes.DISARM,
+                host_phone_number=None,
+                product_name='Dummy product',
+                mcu_hw_version='1.0',
+                wifi_hw_version='1.0',
+            )
+        )
+
+        mock_sensor = pyg90alarm.alarm.G90Sensor(
+            parent=mock.return_value, subindex=0, proto_idx=0,
+            parent_name='Dummy sensor',
+            index=0,
+            room_id=0,
+            type_id=1,
+            subtype=0,
+            timeout=0,
+            user_flag_data=255,
+            baudrate=0,
+            protocol_id=0,
+            reserved_data=0,
+            node_count=0,
+            mask=0,
+            private_data=0,
+        )
+        mock_sensor.set_enabled = AsyncMock()
+        type(mock_sensor).supports_enable_disable = (
+            PropertyMock(return_value=True)
+        )
+
+        mock.return_value.get_sensors = AsyncMock(
+            return_value=[
+                mock_sensor,
+            ]
+        )
+
+        mock.return_value.get_devices = AsyncMock(
+            return_value=[
+                pyg90alarm.alarm.G90Device(
+                    parent=mock.return_value, subindex=0, proto_idx=0,
+                    parent_name='Dummy switch',
+                    index=0,
+                    room_id=0,
+                    type_id=0,
+                    subtype=0,
+                    timeout=0,
+                    user_flag_data=0,
+                    baudrate=0,
+                    protocol_id=0,
+                    reserved_data=0,
+                    node_count=0,
+                    mask=0,
+                    private_data=0,
+                )
+            ]
+        )
+
+        mock.return_value.listen_device_notifications = AsyncMock()
+
+        yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-tbd
+Pytest configuration and fixtures
 """
 from unittest.mock import patch, AsyncMock, PropertyMock
 import pytest
@@ -11,29 +11,39 @@ import pyg90alarm
 # pylint: disable=unused-argument
 def auto_enable_custom_integrations(enable_custom_integrations):
     """
-    tbd
+    Automatically uses `enable_custom_integrations` Homeassistant fixture,
+    since it is required for custom integrations to be loaded during tests.
     """
     yield
 
 
 def pytest_configure(config):
     """
-    tbd
+    Configures `pytest`.
     """
+    # Register `g90discovery` mark allows to specify mocked G90 discovery
+    # results
     config.addinivalue_line("markers", "g90discovery")
 
 
 @pytest.fixture
 def mock_g90alarm(request):
     """
-    tbd
+    Mocks `G90Alarm` instance and its methods relevant to tests.
     """
     with (
+        # Mock `G90Alarm` instance - it is imported into
+        # `custom_components.gs_alarm` namespace using `from pyg90alarm import
+        # G90Alarm`
         patch('custom_components.gs_alarm.G90Alarm', autospec=True) as mock,
+        # Mock `G90Alarm.discover()` class method being imported into
+        # `custom_components.gs_alarm.config_flow` namespace
         patch(
             'custom_components.gs_alarm.config_flow.G90Alarm.discover'
         ) as mock_discover,
     ):
+        # Mocked discovery results, either from `g90discovery` mark (`result`
+        # keyword) or empty list by default
         mock_discover.return_value = (
             getattr(
                 request.node
@@ -42,6 +52,8 @@ def mock_g90alarm(request):
             ).get('result', [])
         )
 
+        # Mock `G90Alarm().get_host_info()` method with dummy product
+        # information
         mock.return_value.get_host_info = AsyncMock(
             return_value=pyg90alarm.alarm.G90HostInfo(
                 host_guid='Dummy',
@@ -60,18 +72,22 @@ def mock_g90alarm(request):
             )
         )
 
+        # Mock `G90Alarm().get_host_info()` method with dummy status
+        # information
         mock.return_value.get_host_status = AsyncMock(
             return_value=pyg90alarm.alarm.G90HostStatus(
                 host_status=pyg90alarm.alarm.G90ArmDisarmTypes.DISARM,
                 host_phone_number=None,
                 product_name='Dummy product',
-                mcu_hw_version='1.0',
-                wifi_hw_version='1.0',
+                mcu_hw_version='1.0-test',
+                wifi_hw_version='1.0-test',
             )
         )
 
+        # Instantiate a dummy sensor to mock in `G90Alarm.get_sensors()`
         mock_sensor = pyg90alarm.alarm.G90Sensor(
-            parent=mock.return_value, subindex=0, proto_idx=0,
+            parent=mock.return_value,  # Has to point to `G90Alarm()` instance
+            subindex=0, proto_idx=0,
             parent_name='Dummy sensor',
             index=0,
             room_id=0,
@@ -86,17 +102,26 @@ def mock_g90alarm(request):
             mask=0,
             private_data=0,
         )
+        # Mock `set_enabled()` method of the sensor, will be used in test
+        # assertions
         mock_sensor.set_enabled = AsyncMock()
+        # Mock `supports_enable_disable` property of the sensor defaulting to
+        # `True`, will later be used by tests to simulate a sensor no
+        # supporting enabling/disabling
         type(mock_sensor).supports_enable_disable = (
             PropertyMock(return_value=True)
         )
 
+        # Mock `G90Alarm().get_sensors()` method pretenting to return single
+        # sensor above
         mock.return_value.get_sensors = AsyncMock(
             return_value=[
                 mock_sensor,
             ]
         )
 
+        # Mock `G90Alarm().get_devices()` method pretenting to return single
+        # device (relay)
         mock.return_value.get_devices = AsyncMock(
             return_value=[
                 pyg90alarm.alarm.G90Device(
@@ -118,6 +143,7 @@ def mock_g90alarm(request):
             ]
         )
 
+        # Mock `G90Alarm().listen_device_notificaitons()` to do nothing
         mock.return_value.listen_device_notifications = AsyncMock()
 
         yield mock

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,5 @@
 """
-tbd
+Tests config flow for the custom component.
 """
 import pytest
 
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from custom_components.gs_alarm.const import DOMAIN
 
 
+# Simulate single device discovered
 @pytest.mark.g90discovery(result=[
     {
         'guid': 'Dummy guid',
@@ -18,39 +19,46 @@ from custom_components.gs_alarm.const import DOMAIN
 ])
 async def test_config_flow_discovered_devices(hass, mock_g90alarm):
     """
-    tbd
+    Tests config flow with single discovered device.
     """
+    # Initial step
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": "user"},
     )
-
+    # Verify it results in form
     assert result['step_id'] == 'confirm'
     assert result['type'] == FlowResultType.FORM
 
+    # Submission step
     result = await hass.config_entries.flow.async_configure(
         flow_id=result['flow_id'],
         user_input={},
     )
+
+    # Verify it results in creating entity of proper type/domain
     assert result['type'] == FlowResultType.CREATE_ENTRY
     assert isinstance(result['result'], ConfigEntry)
     assert result['result'].domain == DOMAIN
-    # Port is ignored
+
+    # Verify `G90Alarm` has been instantiated with proper host, port is ignored
     mock_g90alarm.assert_called_with(host='dummy-discovered-host')
 
 
 async def test_config_flow_manual_device(hass, mock_g90alarm):
     """
-    tbd
+    Tests config flow with no discovered and single manually added device.
     """
+    # Initial step
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": "user"},
     )
-
+    # Verify it results in form
     assert result['step_id'] == 'confirm'
     assert result['type'] == FlowResultType.FORM
 
+    # Submission step confirming to proceed with manual host
     result = await hass.config_entries.flow.async_configure(
         flow_id=result['flow_id'],
         user_input={},
@@ -58,30 +66,37 @@ async def test_config_flow_manual_device(hass, mock_g90alarm):
     assert result['type'] == FlowResultType.FORM
     assert result['step_id'] == 'custom_host'
 
+    # Submittion step confirming the manual host
     result = await hass.config_entries.flow.async_configure(
         flow_id=result['flow_id'],
         user_input={'ip_addr': 'dummy-manual-host'},
     )
+
+    # Verify it results in creating entity of proper type/domain
     assert result['type'] == FlowResultType.CREATE_ENTRY
     assert isinstance(result['result'], ConfigEntry)
     assert result['result'].domain == DOMAIN
-    # Port is ignored
+
+    # Verify `G90Alarm` has been instantiated with proper host, port is ignored
     mock_g90alarm.assert_called_with(host='dummy-manual-host')
 
 
 # pylint: disable=unused-argument
 async def test_config_flow_manual_device_no_ip_addr(hass, mock_g90alarm):
     """
-    tbd
+    Tests config flow wit manual device and omitted input for its hostname/IP
+    address.
     """
+    # Initial step
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": "user"},
     )
-
+    # Verify it results in form
     assert result['step_id'] == 'confirm'
     assert result['type'] == FlowResultType.FORM
 
+    # Submission step confirming to proceed with manual host
     result = await hass.config_entries.flow.async_configure(
         flow_id=result['flow_id'],
         user_input={},
@@ -89,9 +104,11 @@ async def test_config_flow_manual_device_no_ip_addr(hass, mock_g90alarm):
     assert result['type'] == FlowResultType.FORM
     assert result['step_id'] == 'custom_host'
 
+    # Submittion step confirming the manual host providing empty input
     result = await hass.config_entries.flow.async_configure(
         flow_id=result['flow_id'],
         user_input={'ip_addr': ''},
     )
+    # Verify it results in form mentioning the error
     assert result['type'] == FlowResultType.FORM
     assert result['errors']

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,97 @@
+"""
+tbd
+"""
+import pytest
+
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.config_entries import ConfigEntry
+
+from custom_components.gs_alarm.const import DOMAIN
+
+
+@pytest.mark.g90discovery(result=[
+    {
+        'guid': 'Dummy guid',
+        'host': 'dummy-discovered-host',
+        'port': 4321,
+    }
+])
+async def test_config_flow_discovered_devices(hass, mock_g90alarm):
+    """
+    tbd
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+    )
+
+    assert result['step_id'] == 'confirm'
+    assert result['type'] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id=result['flow_id'],
+        user_input={},
+    )
+    assert result['type'] == FlowResultType.CREATE_ENTRY
+    assert isinstance(result['result'], ConfigEntry)
+    assert result['result'].domain == DOMAIN
+    # Port is ignored
+    mock_g90alarm.assert_called_with(host='dummy-discovered-host')
+
+
+async def test_config_flow_manual_device(hass, mock_g90alarm):
+    """
+    tbd
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+    )
+
+    assert result['step_id'] == 'confirm'
+    assert result['type'] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id=result['flow_id'],
+        user_input={},
+    )
+    assert result['type'] == FlowResultType.FORM
+    assert result['step_id'] == 'custom_host'
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id=result['flow_id'],
+        user_input={'ip_addr': 'dummy-manual-host'},
+    )
+    assert result['type'] == FlowResultType.CREATE_ENTRY
+    assert isinstance(result['result'], ConfigEntry)
+    assert result['result'].domain == DOMAIN
+    # Port is ignored
+    mock_g90alarm.assert_called_with(host='dummy-manual-host')
+
+
+# pylint: disable=unused-argument
+async def test_config_flow_manual_device_no_ip_addr(hass, mock_g90alarm):
+    """
+    tbd
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+    )
+
+    assert result['step_id'] == 'confirm'
+    assert result['type'] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id=result['flow_id'],
+        user_input={},
+    )
+    assert result['type'] == FlowResultType.FORM
+    assert result['step_id'] == 'custom_host'
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id=result['flow_id'],
+        user_input={'ip_addr': ''},
+    )
+    assert result['type'] == FlowResultType.FORM
+    assert result['errors']

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,8 +2,6 @@
 tbd
 """
 from datetime import timedelta
-from unittest.mock import patch, AsyncMock
-
 from pytest_unordered import unordered
 
 from pytest_homeassistant_custom_component.common import (
@@ -14,8 +12,6 @@ from homeassistant.util import dt
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 
-import pyg90alarm
-
 from custom_components.gs_alarm import (
     async_setup_entry,
     async_unload_entry,
@@ -23,7 +19,7 @@ from custom_components.gs_alarm import (
 from custom_components.gs_alarm.const import DOMAIN
 
 
-async def test_setup_unload_and_reload_entry(hass):
+async def test_setup_unload_and_reload_entry(hass, mock_g90alarm):
     """
     tbd
     """
@@ -33,102 +29,31 @@ async def test_setup_unload_and_reload_entry(hass):
         options={'disabled_sensors': ['Dummy sensor#1']},
         entry_id="test"
     )
-    config_entry.add_to_hass(hass)
-    with patch('custom_components.gs_alarm.G90Alarm', autospec=True) as mock:
-        mock.return_value.get_host_info = AsyncMock(
-            return_value=pyg90alarm.alarm.G90HostInfo(
-                host_guid='Dummy',
-                product_name='Dummy product',
-                wifi_protocol_version='1.0-test',
-                cloud_protocol_version='1.1-test',
-                mcu_hw_version='1.0-test',
-                wifi_hw_version='1.0-test',
-                gsm_status_data=0,
-                wifi_status_data=0,
-                reserved1=None,
-                reserved2=None,
-                band_frequency=None,
-                gsm_signal_level=100,
-                wifi_signal_level=100,
-            )
-        )
 
-        mock.return_value.get_host_status = AsyncMock(
-            return_value=pyg90alarm.alarm.G90HostStatus(
-                host_status=pyg90alarm.alarm.G90ArmDisarmTypes.DISARM,
-                host_phone_number=None,
-                product_name='Dummy product',
-                mcu_hw_version='1.0',
-                wifi_hw_version='1.0',
-            )
-        )
+    assert await async_setup_entry(hass, config_entry)
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
 
-        mock.return_value.get_sensors = AsyncMock(
-            return_value=[
-                pyg90alarm.alarm.G90Sensor(
-                    parent=mock.return_value, subindex=0, proto_idx=0,
-                    parent_name='Dummy sensor',
-                    index=0,
-                    room_id=0,
-                    type_id=1,
-                    subtype=0,
-                    timeout=0,
-                    user_flag_data=255,
-                    baudrate=0,
-                    protocol_id=0,
-                    reserved_data=0,
-                    node_count=0,
-                    mask=0,
-                    private_data=0,
-                )
-            ]
-        )
-        mock.return_value.get_devices = AsyncMock(
-            return_value=[
-                pyg90alarm.alarm.G90Device(
-                    parent=mock.return_value, subindex=0, proto_idx=0,
-                    parent_name='Dummy switch',
-                    index=0,
-                    room_id=0,
-                    type_id=0,
-                    subtype=0,
-                    timeout=0,
-                    user_flag_data=0,
-                    baudrate=0,
-                    protocol_id=0,
-                    reserved_data=0,
-                    node_count=0,
-                    mask=0,
-                    private_data=0,
-                )
-            ]
-        )
+    mock_g90alarm.assert_called_once_with(host='dummy-ip')
 
-        mock.return_value.listen_device_notifications = AsyncMock()
-        assert await async_setup_entry(hass, config_entry)
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-        await hass.async_block_till_done()
+    integration_devices = dr.async_entries_for_config_entry(
+        dr.async_get(hass), config_entry.entry_id
+    )
+    assert len(integration_devices) == 1
+    integration_device_id = integration_devices[0].id
 
-        mock.assert_called_once_with(host='dummy-ip')
+    integration_entities = er.async_entries_for_device(
+        er.async_get(hass), integration_device_id
+    )
+    integration_entity_ids = [x.entity_id for x in integration_entities]
+    assert integration_entity_ids == unordered([
+        'alarm_control_panel.dummy',
+        'binary_sensor.dummy_sensor_1',
+        'switch.dummy_switch_1',
+        'sensor.gs_alarm_wifi_signal',
+        'binary_sensor.gs_alarm_wifi_status',
+        'sensor.gs_alarm_gsm_signal',
+        'binary_sensor.gs_alarm_gsm_status'
+    ])
 
-        integration_devices = dr.async_entries_for_config_entry(
-            dr.async_get(hass), config_entry.entry_id
-        )
-        assert len(integration_devices) == 1
-        integration_device_id = integration_devices[0].id
-
-        integration_entities = er.async_entries_for_device(
-            er.async_get(hass), integration_device_id
-        )
-        integration_entity_ids = [x.entity_id for x in integration_entities]
-        assert integration_entity_ids == unordered([
-            'alarm_control_panel.dummy',
-            'binary_sensor.dummy_sensor_1',
-            'switch.dummy_switch_1',
-            'sensor.gs_alarm_wifi_signal',
-            'binary_sensor.gs_alarm_wifi_status',
-            'sensor.gs_alarm_gsm_signal',
-            'binary_sensor.gs_alarm_gsm_status'
-        ])
-
-        assert await async_unload_entry(hass, config_entry)
+    assert await async_unload_entry(hass, config_entry)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,134 @@
+"""
+tbd
+"""
+from datetime import timedelta
+from unittest.mock import patch, AsyncMock
+
+from pytest_unordered import unordered
+
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+from homeassistant.util import dt
+import homeassistant.helpers.device_registry as dr
+import homeassistant.helpers.entity_registry as er
+
+import pyg90alarm
+
+from custom_components.gs_alarm import (
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.gs_alarm.const import DOMAIN
+
+
+async def test_setup_unload_and_reload_entry(hass):
+    """
+    tbd
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={'disabled_sensors': ['Dummy sensor#1']},
+        entry_id="test"
+    )
+    config_entry.add_to_hass(hass)
+    with patch('custom_components.gs_alarm.G90Alarm', autospec=True) as mock:
+        mock.return_value.get_host_info = AsyncMock(
+            return_value=pyg90alarm.alarm.G90HostInfo(
+                host_guid='Dummy',
+                product_name='Dummy product',
+                wifi_protocol_version='1.0-test',
+                cloud_protocol_version='1.1-test',
+                mcu_hw_version='1.0-test',
+                wifi_hw_version='1.0-test',
+                gsm_status_data=0,
+                wifi_status_data=0,
+                reserved1=None,
+                reserved2=None,
+                band_frequency=None,
+                gsm_signal_level=100,
+                wifi_signal_level=100,
+            )
+        )
+
+        mock.return_value.get_host_status = AsyncMock(
+            return_value=pyg90alarm.alarm.G90HostStatus(
+                host_status=pyg90alarm.alarm.G90ArmDisarmTypes.DISARM,
+                host_phone_number=None,
+                product_name='Dummy product',
+                mcu_hw_version='1.0',
+                wifi_hw_version='1.0',
+            )
+        )
+
+        mock.return_value.get_sensors = AsyncMock(
+            return_value=[
+                pyg90alarm.alarm.G90Sensor(
+                    parent=mock.return_value, subindex=0, proto_idx=0,
+                    parent_name='Dummy sensor',
+                    index=0,
+                    room_id=0,
+                    type_id=1,
+                    subtype=0,
+                    timeout=0,
+                    user_flag_data=255,
+                    baudrate=0,
+                    protocol_id=0,
+                    reserved_data=0,
+                    node_count=0,
+                    mask=0,
+                    private_data=0,
+                )
+            ]
+        )
+        mock.return_value.get_devices = AsyncMock(
+            return_value=[
+                pyg90alarm.alarm.G90Device(
+                    parent=mock.return_value, subindex=0, proto_idx=0,
+                    parent_name='Dummy switch',
+                    index=0,
+                    room_id=0,
+                    type_id=0,
+                    subtype=0,
+                    timeout=0,
+                    user_flag_data=0,
+                    baudrate=0,
+                    protocol_id=0,
+                    reserved_data=0,
+                    node_count=0,
+                    mask=0,
+                    private_data=0,
+                )
+            ]
+        )
+
+        mock.return_value.listen_device_notifications = AsyncMock()
+        assert await async_setup_entry(hass, config_entry)
+        async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+        await hass.async_block_till_done()
+
+        mock.assert_called_once_with(host='dummy-ip')
+
+        integration_devices = dr.async_entries_for_config_entry(
+            dr.async_get(hass), config_entry.entry_id
+        )
+        assert len(integration_devices) == 1
+        integration_device_id = integration_devices[0].id
+
+        integration_entities = er.async_entries_for_device(
+            er.async_get(hass), integration_device_id
+        )
+        integration_entity_ids = [x.entity_id for x in integration_entities]
+        assert integration_entity_ids == unordered([
+            'alarm_control_panel.dummy',
+            'binary_sensor.dummy_sensor_1',
+            'switch.dummy_switch_1',
+            'sensor.gs_alarm_wifi_signal',
+            'binary_sensor.gs_alarm_wifi_status',
+            'sensor.gs_alarm_gsm_signal',
+            'binary_sensor.gs_alarm_gsm_status'
+        ])
+
+        assert await async_unload_entry(hass, config_entry)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,5 @@
 """
-tbd
+Tests for loading/unloading the custom component.
 """
 from datetime import timedelta
 from pytest_unordered import unordered
@@ -21,7 +21,7 @@ from custom_components.gs_alarm.const import DOMAIN
 
 async def test_setup_unload_and_reload_entry(hass, mock_g90alarm):
     """
-    tbd
+    Tests the custom integration load and then unloads properly.
     """
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -31,17 +31,22 @@ async def test_setup_unload_and_reload_entry(hass, mock_g90alarm):
     )
 
     assert await async_setup_entry(hass, config_entry)
+    # Simulate some time has passed for HomeAssistant to invoke
+    # `async_update()` for components
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
     await hass.async_block_till_done()
 
     mock_g90alarm.assert_called_once_with(host='dummy-ip')
 
+    # Verify single device has been added
     integration_devices = dr.async_entries_for_config_entry(
         dr.async_get(hass), config_entry.entry_id
     )
     assert len(integration_devices) == 1
     integration_device_id = integration_devices[0].id
 
+    # Verify corresponding entities (platforms) have been added under the
+    # device
     integration_entities = er.async_entries_for_device(
         er.async_get(hass), integration_device_id
     )
@@ -57,3 +62,6 @@ async def test_setup_unload_and_reload_entry(hass, mock_g90alarm):
     ])
 
     assert await async_unload_entry(hass, config_entry)
+    await hass.async_block_till_done()
+    # Verify the component cleaned up its data upon unloading
+    assert not hass.data[DOMAIN]

--- a/tests/test_option_flow.py
+++ b/tests/test_option_flow.py
@@ -1,0 +1,81 @@
+"""
+tbd
+"""
+from unittest.mock import PropertyMock
+
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+)
+
+from custom_components.gs_alarm import (
+    async_setup_entry,
+)
+from custom_components.gs_alarm.const import DOMAIN
+
+
+async def test_config_flow_options(hass, mock_g90alarm):
+    """
+    tbd
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+    )
+    await async_setup_entry(hass, config_entry)
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id,
+        context={"source": "user"},
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        flow_id=result['flow_id'],
+        user_input={
+            'sms_alert_when_armed': True,
+            'disabled_sensors': ['0']
+        },
+    )
+    assert result['type'] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+    (
+        mock_g90alarm.return_value
+        .get_sensors.return_value[0]
+        .set_enabled
+    ).assert_called_once_with(False)
+
+    assert mock_g90alarm.return_value.sms_alert_when_armed
+
+
+async def test_config_flow_options_unsupported_disable(hass, mock_g90alarm):
+    """
+    tbd
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+    )
+    await async_setup_entry(hass, config_entry)
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id,
+        context={"source": "user"},
+    )
+
+    (
+        type(mock_g90alarm.return_value.get_sensors.return_value[0])
+        .supports_enable_disable
+    ) = PropertyMock(return_value=False)
+
+    result = await hass.config_entries.options.async_configure(
+        flow_id=result['flow_id'],
+        user_input={'disabled_sensors': ['0']},
+    )
+    assert result['type'] == FlowResultType.CREATE_ENTRY
+    (
+        mock_g90alarm.return_value
+        .get_sensors.return_value[0]
+        .set_enabled
+    ).assert_not_called()

--- a/tests/test_option_flow.py
+++ b/tests/test_option_flow.py
@@ -1,5 +1,5 @@
 """
-tbd
+Tests for option (configure) flow for the custom component.
 """
 from unittest.mock import PropertyMock
 
@@ -16,8 +16,10 @@ from custom_components.gs_alarm.const import DOMAIN
 
 async def test_config_flow_options(hass, mock_g90alarm):
     """
-    tbd
+    Tests options (configure) flow for the component with correct inputs.
     """
+    # Instantiate the component into HomeAssistant, required for its options
+    # flow handler to be registered
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={},
@@ -25,11 +27,17 @@ async def test_config_flow_options(hass, mock_g90alarm):
     await async_setup_entry(hass, config_entry)
     config_entry.add_to_hass(hass)
 
+    # Initial step
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id,
         context={"source": "user"},
     )
+    # Verify it results in form
+    assert result['step_id'] == 'init'
+    assert result['type'] == FlowResultType.FORM
 
+    # Submission step configuring the single mocked sensor to be disabled (by
+    # its index) and enabling `SMS alert only when armed`
     result = await hass.config_entries.options.async_configure(
         flow_id=result['flow_id'],
         user_input={
@@ -37,21 +45,29 @@ async def test_config_flow_options(hass, mock_g90alarm):
             'disabled_sensors': ['0']
         },
     )
+    # Verify it results in (re)creating corresponding entry in HomeAssistant
     assert result['type'] == FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
+    # Verify the sensor has to its `set_enabled()` method invoked with proper
+    # arguments
     (
         mock_g90alarm.return_value
         .get_sensors.return_value[0]
         .set_enabled
     ).assert_called_once_with(False)
 
+    # Verify the value of the `sms_alert_when_armed` property of `G90Alarm()`
+    # instance
     assert mock_g90alarm.return_value.sms_alert_when_armed
 
 
 async def test_config_flow_options_unsupported_disable(hass, mock_g90alarm):
     """
-    tbd
+    Tests options (configure) flow for the component where sensor attempted to
+    disable and it isn't supported.
     """
+    # Instantiate the component into HomeAssistant, required for its options
+    # flow handler to be registered
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={},
@@ -59,21 +75,29 @@ async def test_config_flow_options_unsupported_disable(hass, mock_g90alarm):
     await async_setup_entry(hass, config_entry)
     config_entry.add_to_hass(hass)
 
+    # Initial step
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id,
         context={"source": "user"},
     )
+    # Verify it results in form
+    assert result['step_id'] == 'init'
+    assert result['type'] == FlowResultType.FORM
 
+    # Simulate the sensor doesn't support enabling/disabling
     (
         type(mock_g90alarm.return_value.get_sensors.return_value[0])
         .supports_enable_disable
     ) = PropertyMock(return_value=False)
 
+    # Submission step configuring the single mocked sensor to be disabled
     result = await hass.config_entries.options.async_configure(
         flow_id=result['flow_id'],
         user_input={'disabled_sensors': ['0']},
     )
+    # Verify it results in (re)creating corresponding entry in HomeAssistant
     assert result['type'] == FlowResultType.CREATE_ENTRY
+    # Verify disabling the sensor has not been called
     (
         mock_g90alarm.return_value
         .get_sensors.return_value[0]

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,10 @@ minversion = 3.3.0
 # arguments use the pyproject.toml file as specified in PEP-517 and PEP-518.
 isolated_build = true
 
+# Skip packaging since it is useless due to HACS using different distribution
+# methods
+skipsdist=true
+
 [testenv]
 deps =
     flake8
@@ -26,6 +30,11 @@ deps =
 
 allowlist_externals =
 	cat
+
+setenv =
+	# Allow tests to import the custom compontent using
+	`custom_components.<...>` names
+	PYTHONPATH = {toxinidir}
 
 commands =
     flake8 --tee --output-file=flake8.txt custom_components/

--- a/tox.ini
+++ b/tox.ini
@@ -37,11 +37,11 @@ setenv =
 	PYTHONPATH = {toxinidir}
 
 commands =
-    flake8 --tee --output-file=flake8.txt custom_components/
-    pylint --output-format=parseable --output=pylint.txt custom_components/
+    flake8 --tee --output-file=flake8.txt custom_components/ tests/
+    pylint --output-format=parseable --output=pylint.txt custom_components/ tests/
 	# Ensure only traces for in-repository module is processed, not for one
 	# installed by `tox` (see above for more details)
-    pytest --cov=custom_components/ --cov-append --cov-report=term-missing -v -s tests/
+    pytest --cov=custom_components/ --cov-append --cov-report=term-missing -v tests/ []
 
 commands_post =
 	# Show the `pylint` report to the standard output, to ease fixing the issues reported

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ allowlist_externals =
 
 setenv =
 	# Allow tests to import the custom compontent using
-	`custom_components.<...>` names
+	# `custom_components.<...>` names
 	PYTHONPATH = {toxinidir}
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,39 @@
+[tox]
+envlist = py{39,310}
+
+# Define the minimal tox version required to run;
+# if the host tox is less than this the tool with create an environment and
+# provision it with a tox that satisfies it under provision_tox_env.
+# At least this version is needed for PEP 517/518 support.
+minversion = 3.3.0
+
+# Activate isolated build environment. tox will use a virtual environment
+# to build a source distribution from the source tree. For build tools and
+# arguments use the pyproject.toml file as specified in PEP-517 and PEP-518.
+isolated_build = true
+
+[testenv]
+deps =
+    flake8
+    asynctest
+    pylint
+    coverage
+	pytest-homeassistant-custom-component == 0.12.20
+    pytest
+    pytest-cov
+	pytest-unordered
+	pyg90alarm == 1.8.0
+
+allowlist_externals =
+	cat
+
+commands =
+    flake8 --tee --output-file=flake8.txt custom_components/
+    pylint --output-format=parseable --output=pylint.txt custom_components/
+	# Ensure only traces for in-repository module is processed, not for one
+	# installed by `tox` (see above for more details)
+    pytest --cov=custom_components/ --cov-append --cov-report=term-missing -v -s tests/
+
+commands_post =
+	# Show the `pylint` report to the standard output, to ease fixing the issues reported
+	cat pylint.txt


### PR DESCRIPTION
* Added support enabling/disabling sensors via `Configure` tab on device page

   **NOTE**: If sensor doesn't support enabling/disabling through `pyg90alarm` package it will not be shown on the form, thus requiring mobile application to be managed
* Updated version of `pyg90alarm` dependency for the above
* Added test suite and supporting files (Github Action, Sonar properties)
* Linting fixes