### PR TITLE
Reflect sensor name triggered alarm. Restore options upon load

### DIFF
--- a/custom_components/gs_alarm/__init__.py
+++ b/custom_components/gs_alarm/__init__.py
@@ -20,6 +20,7 @@ async def _enable_disable_sensors(g90_client, disabled_sensors):
     Perform enabling/disabling sensors support that during options (configure)
     flow
     """
+    _LOGGER.debug('Sensors to disable: %s', disabled_sensors)
     for sensor in await g90_client.get_sensors():
         # Calculate target state for the sensor, depending on whether it has
         # been included into `disabled_sensors` configure result or not
@@ -49,10 +50,27 @@ async def options_update_listener(hass, entry):
     Handles options update.
     """
     g90_client = hass.data[DOMAIN][entry.entry_id]['client']
-    g90_client.sms_alert_when_armed = entry.options['sms_alert_when_armed']
-    await _enable_disable_sensors(
-        g90_client, entry.options['disabled_sensors']
+    _LOGGER.debug(
+        'Updating alarm panel from config_entry options %s',
+        entry.options
     )
+
+    sms_alert_when_armed = entry.options.get('sms_alert_when_armed')
+    # Skip updating the property if integration has no options persisted (just
+    # added to HASS)
+    if sms_alert_when_armed is not None:
+        g90_client.sms_alert_when_armed = entry.options.get(
+            'sms_alert_when_armed', False
+        )
+        _LOGGER.debug(
+            'G90Alarm.sms_alert_when_armed: %s',
+            g90_client.sms_alert_when_armed
+        )
+
+    # Skip updating the sensors if integration has no options persisted
+    disabled_sensors = entry.options.get('disabled_sensors')
+    if disabled_sensors is not None:
+        await _enable_disable_sensors(g90_client, disabled_sensors)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -84,6 +102,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await g90_client.listen_device_notifications()
 
     entry.async_on_unload(entry.add_update_listener(options_update_listener))
+    # Force setting options upon entry added
+    await options_update_listener(hass, entry)
 
     return True
 
@@ -92,6 +112,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """
     Unloads the config entry.
     """
+    _LOGGER.debug('Unloading platforms')
     unload_ok = all(
         await asyncio.gather(
             *(
@@ -102,7 +123,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         )
     )
-    _LOGGER.debug('Platforms unloaded')
+    _LOGGER.debug(
+        'Platforms unloaded %successfully', '' if unload_ok else 'un'
+    )
     if unload_ok:
         g90_client = hass.data[DOMAIN][entry.entry_id]['client']
         g90_client.close_device_notifications()

--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -56,13 +56,15 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         )
         self._attr_name = hass_data['guid']
         self._attr_device_info = hass_data['device']
+        self._attr_changed_by = None
         self._state = None
         self._hass_data = hass_data
         self._hass_data['client'].armdisarm_callback = self.armdisarm_callback
+        self._hass_data['client'].alarm_callback = self.alarm_callback
 
     async def add_to_platform_finish(self) -> None:
         """
-        tbd
+        Invoked by HASS when platform is added.
         """
         # Read the state of the alarm panel upon entry is added to the
         # platform, but before its state is persisted. This helps HomeAssistant
@@ -73,16 +75,25 @@ class G90AlarmPanel(AlarmControlPanelEntity):
 
     def armdisarm_callback(self, state):
         """
-        tbd
+        Invoked by `G90Alarm` when panel is armed or disarmed.
         """
         _LOGGER.debug('Received arm/disarm callback: %s', state)
         self._state = STATE_MAPPING[state]
         # Schedule updating HA since the panel state has changed
         self.schedule_update_ha_state()
 
+    def alarm_callback(self, _sensor_idx, sensor_name):
+        """
+        Invoked by `G90Alarm` whan alarm is triggered.
+        """
+        _LOGGER.debug('Received alarm callback: %s', sensor_name)
+        self._attr_changed_by = sensor_name
+        # Schedule updating HA since the panel state has changed
+        self.schedule_update_ha_state()
+
     async def async_update(self):
         """
-        tbd
+        Invoked by HASS when state needs an update.
         """
         _LOGGER.debug('Updating state')
 
@@ -99,7 +110,7 @@ class G90AlarmPanel(AlarmControlPanelEntity):
     @property
     def state(self):
         """
-        tbd
+        Returns the platform state.
         """
         return self._state
 

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/hostcc/hass-gs-alarm/blob/master/README.md",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
-    "pyg90alarm==1.8.0"
+    "pyg90alarm==1.9.0"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
* Alarm panel now shows the sensor name triggered an alarm, leveraging alarm callback recently added to `pyg90alarm.G90Alarm`. As an additional benefit the alarm panel changes its state when alarmed quicker, not deferring to next update interval
* Options are now properly restored upon integration is loaded, if they have been persisted in HASS already (i.e. integration has already been added and configured)