### PR TITLE
Provide sensor entity ID as `changed_by` to alarm panel when triggered

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,7 @@ jobs:
           # history
           fetch-depth: 0
       - name: Set Python up
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install testing tools

--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -74,16 +74,19 @@ class G90BinarySensor(BinarySensorEntity):
     """
     tbd
     """
-    def __init__(self, sensor: object, hass_data: dict) -> None:
-        self._sensor = sensor
-        self._attr_unique_id = f"{hass_data['guid']}_sensor_{sensor.index}"
-        self._attr_name = sensor.name
-        hass_sensor_type = HASS_SENSOR_TYPES_MAPPING.get(sensor.type, None)
+    def __init__(self, g90_sensor: object, hass_data: dict) -> None:
+        self._g90_sensor = g90_sensor
+        self._attr_unique_id = f"{hass_data['guid']}_sensor_{g90_sensor.index}"
+        self._attr_name = g90_sensor.name
+        hass_sensor_type = HASS_SENSOR_TYPES_MAPPING.get(g90_sensor.type, None)
         if hass_sensor_type:
             self._attr_device_class = hass_sensor_type
-        sensor.state_callback = self.state_callback
+        g90_sensor.state_callback = self.state_callback
         self._attr_device_info = hass_data['device']
         self._hass_data = hass_data
+        # Store the entiry ID as extra data to `G90Sensor` instance, it will be
+        # provided in the arguments when `G90Alarm.alarm_callback` is invoked
+        self._g90_sensor.extra_data = self.entity_id
 
     def state_callback(self, value):
         """
@@ -97,7 +100,7 @@ class G90BinarySensor(BinarySensorEntity):
         """
         tbd
         """
-        val = self._sensor.occupancy
+        val = self._g90_sensor.occupancy
         _LOGGER.debug('%s: Providing state %s', self.unique_id, val)
         return val
 

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/hostcc/hass-gs-alarm/blob/master/README.md",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
-    "pyg90alarm==1.9.0"
+    "pyg90alarm==1.10.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,97 @@
+"""
+Tests callbacks for the custom component.
+"""
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+)
+from pyg90alarm.const import G90ArmDisarmTypes
+
+from custom_components.gs_alarm import (
+    async_setup_entry,
+)
+from custom_components.gs_alarm.const import DOMAIN
+
+
+@pytest.mark.g90host_status(
+    result=G90ArmDisarmTypes.DISARM
+)
+async def test_alarm_callback(hass, mock_g90alarm):
+    """
+    Tests the alarm panel changes its state upon alarm callback is triggered.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test-alarm-callbacks"
+    )
+
+    assert await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    # Simulate the alarm callback is triggered
+    mock_g90alarm.return_value.alarm_callback(
+        1, 'Dummy', 'binary_sensor.dummy_1'
+    )
+
+    # Verify panel state and attributes reflect that
+    panel_state = hass.states.get('alarm_control_panel.dummy')
+    assert panel_state.state == 'triggered'
+    assert panel_state.attributes.get('changed_by') == 'binary_sensor.dummy_1'
+
+
+@pytest.mark.g90host_status(
+    result=G90ArmDisarmTypes.DISARM
+)
+async def test_arm_callback(hass, mock_g90alarm):
+    """
+    Tests the alarm panel changes its state upon arm callback is triggered for
+    arming away.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test-arm-callbacks"
+    )
+
+    assert await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    # Simulate the arm callback is triggered
+    mock_g90alarm.return_value.armdisarm_callback(
+        G90ArmDisarmTypes.ARM_AWAY
+    )
+
+    # Verify panel state reflects that
+    panel_state = hass.states.get('alarm_control_panel.dummy')
+    assert panel_state.state == 'armed_away'
+
+
+@pytest.mark.g90host_status(
+    result=G90ArmDisarmTypes.ARM_AWAY
+)
+async def test_disarm_callback(hass, mock_g90alarm):
+    """
+    Tests the alarm panel changes its state upon arm callback is triggered for
+    disarming.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test-disarm-callbacks"
+    )
+
+    assert await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    # Simulate the disarm callback is triggered
+    mock_g90alarm.return_value.armdisarm_callback(
+        G90ArmDisarmTypes.DISARM
+    )
+
+    # Verify panel state reflects that
+    panel_state = hass.states.get('alarm_control_panel.dummy')
+    assert panel_state.state == 'disarmed'


### PR DESCRIPTION
* Alarm panel now should properly reflect the sensor entity that triggers alarm. That is achieved by storing `entity_id` of HASS sensor to `G90Sensor.extra_data`, which will then be provided when `G90Alarm.alarm_callback` is invoked by `pyg90alarm`. That way, `alarm_control_panel` platfrom of the integration can set its `changed_by` attribute
* Alarm control panel now calls `async_write_ha_state()` method to upon changing its state making HASS reflecting that quicker (previously `schedule_update_ha_state()` method had been used that led to some delays)