### PR TITLE
Fix for disabled sensors list in configuration

### DIFF
--- a/custom_components/gs_alarm/config_flow.py
+++ b/custom_components/gs_alarm/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectOptionDict,
+    SelectSelectorMode,
 )
 from pyg90alarm import G90Alarm
 
@@ -165,6 +166,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     SelectSelectorConfig(
                         options=all_sensors,
                         multiple=True,
+                        mode=SelectSelectorMode.LIST,
                     )
                 ),
             })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ local_scheme = "no-local-version"
 [tool.pytest.ini_options]
 log_cli = 1
 log_cli_level = "error"
+# Workaround for
+# https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/129
+asyncio_mode = "auto"

--- a/tox.ini
+++ b/tox.ini
@@ -18,15 +18,14 @@ skipsdist=true
 
 [testenv]
 deps =
-    flake8
-    asynctest
-    pylint
-    coverage
-	pytest-homeassistant-custom-component == 0.12.20
-    pytest
-    pytest-cov
-	pytest-unordered
-	pyg90alarm == 1.8.0
+    flake8==6.0.0
+    pylint==2.15.9
+    coverage==7.0.0
+    pytest-homeassistant-custom-component==0.12.37
+    pytest==7.2.0
+    pytest-cov==3.0.0
+    pytest-unordered==0.5.2
+    pyg90alarm == 1.10.0
 
 allowlist_externals =
 	cat


### PR DESCRIPTION
* `config_flow.py`: Use `list` mode (instead of default `dropdown`) for selector over disabled sensors, otherwise recent HomeAssistant might not be showing up the whole set (by an unidentified reason)

## Additionally
* Tests: applied workaround for https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/129
* `tox`: Pinned dependency versions to ensure reproducible results