### PR TITLE
Default device class for WiFi/GSM signal strength

### DIFF
--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -6,9 +6,10 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
     BinarySensorDeviceClass,
 )
 
@@ -115,6 +116,7 @@ class G90WifiStatusSensor(BinarySensorEntity):
         self._attr_name = f'{DOMAIN}: WiFi Status'
         self._attr_unique_id = f"{hass_data['guid']}_sensor_wifi_status"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_device_info = hass_data['device']
         self._hass_data = hass_data
 
@@ -138,6 +140,7 @@ class G90GsmStatusSensor(BinarySensorEntity):
         self._attr_name = f'{DOMAIN}: GSM Status'
         self._attr_unique_id = f"{hass_data['guid']}_sensor_gsm_status"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_device_info = hass_data['device']
         self._hass_data = hass_data
 

--- a/custom_components/gs_alarm/sensor.py
+++ b/custom_components/gs_alarm/sensor.py
@@ -6,10 +6,10 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
-from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor import (
-    SensorDeviceClass,
+    SensorEntity,
     SensorStateClass,
 )
 from homeassistant.const import (
@@ -59,9 +59,10 @@ class G90WifiSignal(G90BaseSensor):
         super().__init__(*args, **kwargs)
         self._attr_name = f'{DOMAIN}: WiFi Signal'
         self._attr_unique_id = f"{self._hass_data['guid']}_sensor_wifi_signal"
-        self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+        self._attr_icon = 'mdi:wifi'
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_update(self):
         """
@@ -81,9 +82,10 @@ class G90GsmSignal(G90BaseSensor):
         super().__init__(*args, **kwargs)
         self._attr_name = f'{DOMAIN}: GSM Signal'
         self._attr_unique_id = f"{self._hass_data['guid']}_sensor_gsm_signal"
-        self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+        self._attr_icon = 'mdi:signal'
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_update(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     flake8==6.0.0
     pylint==2.15.9
     coverage==7.0.0
-    pytest-homeassistant-custom-component==0.12.37
+    pytest-homeassistant-custom-component==0.12.42
     pytest==7.2.0
     pytest-cov==3.0.0
     pytest-unordered==0.5.2


### PR DESCRIPTION
* Moved WiFi/GSM signal strength sensors to default device class for HASS 2023.1 compatibility - HASS now requires devices of signal strength class to use dBm as UOM, while the panel provides percentage values
* WiFi/GSM signal/connectivity sensors are now under diagnostic category for better representation