### PR TITLE
[Tests] Dependency updates, moved to Python 3.11

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,10 +33,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.9'
-            toxenv: py
-          - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             toxenv: py
     runs-on: ${{ matrix.os }}
     steps:

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -1,16 +1,16 @@
 {
   "domain": "gs_alarm",
   "name": "Golden Security Alarm",
-  "version": "0.0.0",
+  "codeowners": [
+    "@hostcc"
+  ],
   "config_flow": true,
+  "dependencies": [],
   "documentation": "https://github.com/hostcc/hass-gs-alarm/blob/master/README.md",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
     "pyg90alarm==1.10.0"
   ],
-  "dependencies": [],
-  "codeowners": [
-    "@hostcc"
-  ],
-  "iot_class": "local_polling"
+  "version": "0.0.0"
 }

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -7,9 +7,6 @@ from pytest_homeassistant_custom_component.common import (
 )
 from pyg90alarm.const import G90ArmDisarmTypes
 
-from custom_components.gs_alarm import (
-    async_setup_entry,
-)
 from custom_components.gs_alarm.const import DOMAIN
 
 
@@ -26,8 +23,9 @@ async def test_alarm_callback(hass, mock_g90alarm):
         options={},
         entry_id="test-alarm-callbacks"
     )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert await async_setup_entry(hass, config_entry)
     await hass.async_block_till_done()
 
     # Simulate the alarm callback is triggered
@@ -55,8 +53,9 @@ async def test_arm_callback(hass, mock_g90alarm):
         options={},
         entry_id="test-arm-callbacks"
     )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert await async_setup_entry(hass, config_entry)
     await hass.async_block_till_done()
 
     # Simulate the arm callback is triggered
@@ -84,7 +83,8 @@ async def test_disarm_callback(hass, mock_g90alarm):
         entry_id="test-disarm-callbacks"
     )
 
-    assert await async_setup_entry(hass, config_entry)
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     # Simulate the disarm callback is triggered

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,7 +13,6 @@ import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 
 from custom_components.gs_alarm import (
-    async_setup_entry,
     async_unload_entry,
 )
 from custom_components.gs_alarm.const import DOMAIN
@@ -30,8 +29,9 @@ async def test_setup_unload_and_reload_entry_afresh(hass, mock_g90alarm):
         options={},
         entry_id="test"
     )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert await async_setup_entry(hass, config_entry)
     # Simulate some time has passed for HomeAssistant to invoke
     # `async_update()` for components
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
@@ -90,8 +90,9 @@ async def test_setup_entry_with_persisted_options(hass, mock_g90alarm):
         },
         entry_id="test"
     )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert await async_setup_entry(hass, config_entry)
     await hass.async_block_till_done()
 
     # Verify `G90Alarm` instance has been configured according to integration

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py{39,310}
+# Python 3.10 is no longer supported by HASS, see
+# https://github.com/home-assistant/core/pull/98640
+envlist = py{311}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and
@@ -20,10 +22,10 @@ skipsdist=true
 deps =
     flake8==6.0.0
     pylint==2.15.9
-    coverage==7.0.0
-    pytest-homeassistant-custom-component==0.12.42
-    pytest==7.2.0
-    pytest-cov==3.0.0
+    coverage==7.3.2
+    pytest-homeassistant-custom-component==0.13.77
+    pytest==7.4.3
+    pytest-cov==4.1.0
     pytest-unordered==0.5.2
     pyg90alarm == 1.10.0
 


### PR DESCRIPTION
* `tox`: Dependencies update
* `tox`: Moved to Python 3.11 as older versions aren't supported by recent HASS
* `tests/`: Updated code adds test entries to avoid error re: missing `entity_id`