### PR TITLE
Fixed propagation of `changed_by` attribute when alarm is triggered

### DIFF
--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -85,8 +85,17 @@ class G90BinarySensor(BinarySensorEntity):
         g90_sensor.state_callback = self.state_callback
         self._attr_device_info = hass_data['device']
         self._hass_data = hass_data
-        # Store the entiry ID as extra data to `G90Sensor` instance, it will be
+
+    async def async_added_to_hass(self) -> None:
+        """
+        Invoked by HASS when entity is added.
+        """
+        # Store the entity ID as extra data to `G90Sensor` instance, it will be
         # provided in the arguments when `G90Alarm.alarm_callback` is invoked
+        _LOGGER.debug(
+            'Storing entity ID as extra data: sensor %s (idx %s), ID: %s',
+            self._g90_sensor.name, self._g90_sensor.index, self.entity_id
+        )
         self._g90_sensor.extra_data = self.entity_id
 
     def state_callback(self, value):

--- a/tests/test_option_flow.py
+++ b/tests/test_option_flow.py
@@ -8,9 +8,6 @@ from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
 
-from custom_components.gs_alarm import (
-    async_setup_entry,
-)
 from custom_components.gs_alarm.const import DOMAIN
 
 
@@ -24,8 +21,8 @@ async def test_config_flow_options(hass, mock_g90alarm):
         domain=DOMAIN,
         data={},
     )
-    await async_setup_entry(hass, config_entry)
     config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
 
     # Initial step
     result = await hass.config_entries.options.async_init(
@@ -72,8 +69,8 @@ async def test_config_flow_options_unsupported_disable(hass, mock_g90alarm):
         domain=DOMAIN,
         data={},
     )
-    await async_setup_entry(hass, config_entry)
     config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
 
     # Initial step
     result = await hass.config_entries.options.async_init(


### PR DESCRIPTION
* `custom_components/gs_alarm/binary_sensor.py`: HASS entity ID is now stored to `G90BinarySensor.extra_data` only when available (=HASS finished creating corresponding entity and allocated its ID)
* `tests`: Fixed exceptions reported by HASS test harness, mostly related to unloading platform and options flow