### PR TITLE
Reset `changed_by` attribute upon panel is armed/disarmed

### DIFF
--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -80,6 +80,10 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         """
         _LOGGER.debug('Received arm/disarm callback: %s', state)
         self._state = STATE_MAPPING[state]
+        # Reset `changed_by` attribute so the value it possibly has (name of
+        # sensor caused last alarm) isn't carried on indefinitely which might
+        # be confusing
+        self._attr_changed_by = None
         # Update HA entity since the panel state has changed
         self.async_write_ha_state()
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -38,6 +38,14 @@ async def test_alarm_callback(hass, mock_g90alarm):
     assert panel_state.state == 'triggered'
     assert panel_state.attributes.get('changed_by') == 'binary_sensor.dummy_1'
 
+    # Simulate the arm callback is triggered
+    mock_g90alarm.return_value.armdisarm_callback(
+        G90ArmDisarmTypes.ARM_AWAY
+    )
+    # Verify `changed_by` attribute has been reset
+    panel_state = hass.states.get('alarm_control_panel.dummy')
+    assert panel_state.attributes.get('changed_by') is None
+
 
 @pytest.mark.g90host_status(
     result=G90ArmDisarmTypes.DISARM


### PR DESCRIPTION
* `changed_by` attribute is reset upon panel arm/disarm, so the value it  possibly has (name of sensor caused last alarm) isn't carried on  indefinitely which might be confusing