### PR TITLE
Migrate to use features enum of alarm control panel (2024.1.0+)

### DIFF
--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -12,8 +12,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.alarm_control_panel.const import (
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_HOME,
+    AlarmControlPanelEntityFeature
 )
 
 from homeassistant.const import (
@@ -46,13 +45,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 
 
 class G90AlarmPanel(AlarmControlPanelEntity):
+    # Not all base class methods are meaningfull in the context of the
+    # integration, silence the `pylint` for those
+    # pylint: disable=abstract-method
     """
     Instantiate entity for alarm control panel.
     """
     def __init__(self, hass_data: dict) -> None:
         self._attr_unique_id = hass_data['guid']
         self._attr_supported_features = (
-            SUPPORT_ALARM_ARM_AWAY | SUPPORT_ALARM_ARM_HOME
+            AlarmControlPanelEntityFeature.ARM_HOME
+            | AlarmControlPanelEntityFeature.ARM_AWAY
         )
         self._attr_name = hass_data['guid']
         self._attr_device_info = hass_data['device']

--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -27,6 +27,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 
 
 class G90Switch(SwitchEntity):
+    # Not all base class methods are meaningfull in the context of the
+    # integration, silence the `pylint` for those
+    # pylint: disable=abstract-method
     """
     tbd
     """

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,8 @@ skipsdist=true
 deps =
     flake8==6.0.0
     pylint==2.15.9
-    coverage==7.3.2
-    pytest-homeassistant-custom-component==0.13.77
+    coverage==7.3.4
+    pytest-homeassistant-custom-component==0.13.88
     pytest==7.4.3
     pytest-cov==4.1.0
     pytest-unordered==0.5.2


### PR DESCRIPTION
* Features enum `AlarmControlPanelEntityFeature` of the `alarm_control_panel` is now used as stated in [Deprecating all magic numbers for supported features](https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/) HASS article, that is to remove deprecation warning with HASS 2024.1.0 onwards
* `tox`: Moved to latest version of `pytest-homeassistant-custom-component` package to test against most recent HASS release
* `G90AlarmPanel`, `G90Switch` classes now silent `pylint` error re: abstract methods not being overriding as some of those aren't meaningful in the context of the integration