### PR TITLE
No code is required to arm

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,10 +33,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             toxenv: py
           - os: ubuntu-latest
-            python: '3.12'
+            python: '3.13'
             toxenv: py
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,10 +33,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.12'
+            python: '3.11'
             toxenv: py
           - os: ubuntu-latest
-            python: '3.13'
+            python: '3.12'
             toxenv: py
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,9 +33,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.11'
-            toxenv: py
-          - os: ubuntu-latest
             python: '3.12'
             toxenv: py
     runs-on: ${{ matrix.os }}

--- a/custom_components/gs_alarm/__init__.py
+++ b/custom_components/gs_alarm/__init__.py
@@ -22,6 +22,9 @@ async def _enable_disable_sensors(g90_client, disabled_sensors):
     """
     _LOGGER.debug('Sensors to disable: %s', disabled_sensors)
     for sensor in await g90_client.get_sensors():
+        # Ensure no attempts made to disable sensors not supporting that
+        if not sensor.supports_enable_disable:
+            continue
         # Calculate target state for the sensor, depending on whether it has
         # been included into `disabled_sensors` configure result or not
         enable_sensor = (

--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -47,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 class G90AlarmPanel(AlarmControlPanelEntity):
     # Not all base class methods are meaningfull in the context of the
     # integration, silence the `pylint` for those
-    # pylint: disable=abstract-method
+    # pylint: disable=abstract-method, too-many-instance-attributes
     """
     Instantiate entity for alarm control panel.
     """
@@ -57,6 +57,7 @@ class G90AlarmPanel(AlarmControlPanelEntity):
             AlarmControlPanelEntityFeature.ARM_HOME
             | AlarmControlPanelEntityFeature.ARM_AWAY
         )
+        self._attr_code_arm_required = False
         self._attr_name = hass_data['guid']
         self._attr_device_info = hass_data['device']
         self._attr_changed_by = None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -73,7 +73,7 @@ async def test_setup_unload_and_reload_entry_afresh(hass, mock_g90alarm):
         assert re.search(r'^(sensor|binary_sensor)\..+$', sensor.extra_data)
 
     # Unload the integration
-    await hass.config_entries.async_forward_entry_unload(config_entry, DOMAIN)
+    await hass.config_entries.async_unload(config_entry.entry_id, DOMAIN)
     await hass.async_block_till_done()
     # Verify the component cleaned up its data upon unloading
     assert not hass.data[DOMAIN]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Python 3.10 is no longer supported by HASS, see
 # https://github.com/home-assistant/core/pull/98640
-envlist = py{312}
+envlist = py{312,313}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Python 3.10 is no longer supported by HASS, see
 # https://github.com/home-assistant/core/pull/98640
-envlist = py{311,312}
+envlist = py{312}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and
@@ -22,11 +22,11 @@ skipsdist=true
 deps =
     flake8==7.0.0
     pylint==3.0.3
-    coverage==7.4.1
-    pytest-homeassistant-custom-component==0.13.100
-    pytest==7.4.4
-    pytest-cov==4.1.0
-    pytest-unordered==0.5.2
+    coverage==7.5.0
+    pytest-homeassistant-custom-component==0.13.132
+    pytest==8.2.0
+    pytest-cov==5.0.0
+    pytest-unordered==0.6.0
     pyg90alarm == 1.10.0
 
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Python 3.10 is no longer supported by HASS, see
 # https://github.com/home-assistant/core/pull/98640
-envlist = py{312,313}
+envlist = py{312}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and


### PR DESCRIPTION
* Alarm control panel is configured to skip requiring code to arm/disarm, https://developers.home-assistant.io/blog/2024/05/22/alarm_control_panel_validation
* Tests updated to most recent version of mocks (`pytest-homeassistant-custom-component` package and its dependencies). Subsequently, Python 3.11 has been removed from tests since newer HomeAssistant required Python 3.12 and above