### PR TITLE
Support simulating device alerts from history

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ integration will have additional limitations:
 * Delays reflecting panel status up to 30 seconds
 * Sensor state changes will be absent
 
+**NOTE**
+To work around the limitation above the integration now supports simulating the
+device alerts from the history it records - it is implemented by
+[pyg90alarm](https://pypi.org/project/pyg90alarm/) Python package, and it does
+so by periodically polling the device history and sending newer entries down
+the code path as if those been received from device.
+The mode is enabled by selecting `Simulate device alerts from history` option
+in device configuration, and enabling particular device alerts types you're
+interested in via mobile application.
+This mode will still have limitations as not reflecting the state of motion
+sensors (as those come as device notifications not alerts).
+
 Additionally, you might want to enable door close alerts ("Alarm Alert -> Door
 close" in mobile application), so the integration properly reflects the state
 of a door sensor.  Not enabling it will lead the sensor to become inactive in 3
@@ -52,10 +64,10 @@ SMS messages if you enabled those in mobile application) to be sent.
   integration to be reloaded, it currently does not support making those
   updates available in HomeAssistant without the restart
 * If your alarm panel is in a subnet different from one HomeAssistant runs,
-  making the intergration receiving the device notification messages will
+  making the integration receiving the device notification messages will
   require additional steps - the notifications are sent by alarm panel as
   broadcast packets, thus you'll need those forwarded to the HomeAssistant
-  subnet
+  subnet. Alternatively, you could consider the alert simulation option above.
 
 
 ## Troubleshooting

--- a/custom_components/gs_alarm/__init__.py
+++ b/custom_components/gs_alarm/__init__.py
@@ -70,6 +70,17 @@ async def options_update_listener(hass, entry):
             g90_client.sms_alert_when_armed
         )
 
+    simulate_alerts_from_history = entry.options.get(
+        'simulate_alerts_from_history'
+    )
+    if simulate_alerts_from_history is not None:
+        if simulate_alerts_from_history:
+            _LOGGER.debug('Starting to simulate device alerts from history')
+            await g90_client.start_simulating_alerts_from_history()
+        else:
+            _LOGGER.debug('Stopping to simulate device alerts from history')
+            await g90_client.stop_simulating_alerts_from_history()
+
     # Skip updating the sensors if integration has no options persisted
     disabled_sensors = entry.options.get('disabled_sensors')
     if disabled_sensors is not None:

--- a/custom_components/gs_alarm/config_flow.py
+++ b/custom_components/gs_alarm/config_flow.py
@@ -131,6 +131,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     "sms_alert_when_armed", False
                 ),
             ): BooleanSelector(),
+            vol.Required(
+                "simulate_alerts_from_history",
+                default=self.config_entry.options.get(
+                    "simulate_alerts_from_history", False
+                ),
+            ): BooleanSelector(),
         }
 
         # `G90Alarm` instance might be missing, for example if integration has

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
-    "pyg90alarm==1.11.0"
+    "pyg90alarm==1.12.0"
   ],
   "version": "0.0.0"
 }

--- a/custom_components/gs_alarm/strings.json
+++ b/custom_components/gs_alarm/strings.json
@@ -21,6 +21,7 @@
       "init": {
         "data": {
           "sms_alert_when_armed": "SMS alerts only when device is armed",
+          "simulate_alerts_from_history": "Simulate device alerts from history",
           "disabled_sensors": "Disabled sensors"
         }
       }

--- a/custom_components/gs_alarm/translations/en.json
+++ b/custom_components/gs_alarm/translations/en.json
@@ -21,6 +21,7 @@
             "init": {
                 "data": {
                     "sms_alert_when_armed": "SMS alerts only when device is armed",
+                    "simulate_alerts_from_history": "Simulate device alerts from history",
                     "disabled_sensors": "Disabled sensors"
                 }
             }

--- a/tests/test_option_flow.py
+++ b/tests/test_option_flow.py
@@ -39,7 +39,8 @@ async def test_config_flow_options(hass, mock_g90alarm):
         flow_id=result['flow_id'],
         user_input={
             'sms_alert_when_armed': True,
-            'disabled_sensors': ['0']
+            'disabled_sensors': ['0'],
+            'simulate_alerts_from_history': True,
         },
     )
     # Verify it results in (re)creating corresponding entry in HomeAssistant
@@ -56,6 +57,10 @@ async def test_config_flow_options(hass, mock_g90alarm):
     # Verify the value of the `sms_alert_when_armed` property of `G90Alarm()`
     # instance
     assert mock_g90alarm.return_value.sms_alert_when_armed
+
+    # Verify simulating device alerts from history has been started
+    (mock_g90alarm.return_value
+        .start_simulating_alerts_from_history.assert_called())
 
 
 async def test_config_flow_options_unsupported_disable(hass, mock_g90alarm):

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     pytest==8.2.0
     pytest-cov==5.0.0
     pytest-unordered==0.6.0
-    pyg90alarm == 1.10.0
+    pyg90alarm == 1.12.0
 
 allowlist_externals =
 	cat


### PR DESCRIPTION
* Added `Simulate device alerts from history` configuration option to allow treating new device history records as if those have been received from the device as alerts. This will help alleviating the limitation with broadcast connectivity or device's IP address being different from `10.10.10.250`