### PR TITLE
Update `pyg90alarm` version

### DIFF
--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
   "requirements": [
-    "pyg90alarm==1.12.0"
+    "pyg90alarm==1.12.1"
   ],
   "version": "0.0.0"
 }

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     pytest==8.2.0
     pytest-cov==5.0.0
     pytest-unordered==0.6.0
-    pyg90alarm == 1.12.0
+    pyg90alarm == 1.12.1
 
 allowlist_externals =
 	cat


### PR DESCRIPTION
* `pyg90alarm` of `1.12.1` fixes issue with certain excaptions simulating alerts from history aren't ignored, resulting in simulation task to end hence breaking the function