### PR TITLE
[Github] Use release tag name for `manifest.json`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,32 +13,17 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4
         with:
-          # Branches/tags should be available for semver action below to pick
-          # next version
-          fetch-depth: 0
+          # No history needed
+          fetch-depth: 1
           # Git will use deploy SSH key, mostly to push to default branch being
           # protected
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-
-      - name: Generate next version
-        id: version
-        uses: ietf-tools/semver-action@v1
-        with:
-          token: ${{ github.token }}
-          # Pick either current branch for PR or the default branch to find the
-          # version from (the former is only needed for testing the workflow in
-          # an PR)
-          branch: >-
-            ${{
-              github.head_ref
-              || github.event.repository.default_branch
-            }}
 
       - name: Set version in manifest and commit that
         uses: maxgfr/github-change-json@v0.0.26
         with:
           key: version
-          value: ${{ steps.version.outputs.nextStrict }}
+          value: ${{ github.event.release.tag_name }}
           path: custom_components/gs_alarm/manifest.json
 
       - name: Commit updated manifest


### PR DESCRIPTION
* `release.yaml` workflow now uses `github.event.release.tag_name` for the version to put into `manifest.json`, no need to generate the semver