### PR TITLE
fix: Adjusted triggers for automatic releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,10 @@ name: release
 on:
   push:
     branches: [master, main]
-  pull_request:
 
 jobs:
   automatic-release:
-    name: Update manifest
+    name: Automatic release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
@@ -64,6 +63,7 @@ jobs:
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
+          # Base the release off of the tip of default branch
           commit: ${{ github.event.repository.default_branch }}
           token: ${{ github.token }}
           allowUpdates: false


### PR DESCRIPTION
* `release.yaml`: Removed `pull_request` trigger used for testing, updated the workflow name