### PR TITLE
fix: Typing hints. Proper device identifiers

### DIFF
--- a/custom_components/gs_alarm/__init__.py
+++ b/custom_components/gs_alarm/__init__.py
@@ -2,6 +2,7 @@
 The `gs_alarm` integration.
 """
 from __future__ import annotations
+from typing import List
 import asyncio
 import logging
 
@@ -16,7 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["alarm_control_panel", "switch", "binary_sensor", "sensor"]
 
 
-async def _enable_disable_sensors(g90_client, disabled_sensors):
+async def _enable_disable_sensors(
+    g90_client: G90Alarm, disabled_sensors: List[str]
+) -> None:
     """
     Perform enabling/disabling sensors support that during options (configure)
     flow
@@ -49,7 +52,9 @@ async def _enable_disable_sensors(g90_client, disabled_sensors):
         await sensor.set_enabled(enable_sensor)
 
 
-async def options_update_listener(hass, entry):
+async def options_update_listener(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
     """
     Handles options update.
     """
@@ -102,9 +107,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Will periodically be updated by `G90AlarmPanel`
         'host_info': host_info,
         'device': DeviceInfo(
-            identifiers=set(
+            identifiers={
                 (DOMAIN, host_info.host_guid)
-            ),
+            },
             manufacturer='Golden Security',
             model=host_info.product_name,
             name=f'{DOMAIN}:{host_info.host_guid}',

--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -2,6 +2,7 @@
 Alarm control panel component.
 """
 from __future__ import annotations
+from typing import Any
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -20,6 +21,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
+    STATE_UNKNOWN,
 )
 
 from pyg90alarm.const import G90ArmDisarmTypes
@@ -51,7 +53,7 @@ class G90AlarmPanel(AlarmControlPanelEntity):
     """
     Instantiate entity for alarm control panel.
     """
-    def __init__(self, hass_data: dict) -> None:
+    def __init__(self, hass_data: dict[str, Any]) -> None:
         self._attr_unique_id = hass_data['guid']
         self._attr_supported_features = (
             AlarmControlPanelEntityFeature.ARM_HOME
@@ -61,7 +63,7 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         self._attr_name = hass_data['guid']
         self._attr_device_info = hass_data['device']
         self._attr_changed_by = None
-        self._state = None
+        self._state = STATE_UNKNOWN
         self._hass_data = hass_data
         self._hass_data['client'].armdisarm_callback = self.armdisarm_callback
         self._hass_data['client'].alarm_callback = self.alarm_callback
@@ -78,7 +80,7 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         await super().add_to_platform_finish()
 
     @callback
-    def armdisarm_callback(self, state):
+    def armdisarm_callback(self, state: G90ArmDisarmTypes) -> None:
         """
         Invoked by `G90Alarm` when panel is armed or disarmed.
         """
@@ -92,7 +94,9 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         self.async_write_ha_state()
 
     @callback
-    def alarm_callback(self, sensor_idx, sensor_name, extra_data):
+    def alarm_callback(
+        self, sensor_idx: int, sensor_name: str, extra_data: str
+    ) -> None:
         """
         Invoked by `G90Alarm` whan alarm is triggered.
 
@@ -118,7 +122,7 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         # Update HA entity since the panel state has changed
         self.async_write_ha_state()
 
-    async def async_update(self):
+    async def async_update(self) -> None:
         """
         Invoked by HASS when state needs an update.
         """
@@ -135,7 +139,7 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         )
 
     @property
-    def state(self):
+    def state(self) -> str:
         """
         Returns the platform state.
         """

--- a/custom_components/gs_alarm/diagnostics.py
+++ b/custom_components/gs_alarm/diagnostics.py
@@ -2,13 +2,13 @@
 Diagnostics support for the integration.
 """
 from __future__ import annotations
-from typing import Any
+from typing import Any, cast
 
 import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceEntry
-from homeassistant.helpers.redact import async_redact_data
+from homeassistant.components.diagnostics.util import async_redact_data
 from pyg90alarm.entities.sensor import G90Sensor
 from pyg90alarm.entities.device import G90Device
 from pyg90alarm.exceptions import G90Error, G90TimeoutError
@@ -28,7 +28,9 @@ async def async_get_config_entry_diagnostics(
     """
     Returns diagnostics for the config entry.
     """
-    return await async_get_device_diagnostics(hass, entry, None)
+    return await async_get_device_diagnostics(
+        hass, entry, cast(DeviceEntry, None)
+    )
 
 
 def format_g90_sensor_device(sensor: G90Sensor | G90Device) -> dict[str, Any]:
@@ -93,7 +95,7 @@ async def async_get_device_diagnostics(
             },
         }
 
-        return async_redact_data(result, TO_REDACT)
+        return cast(dict[str, Any], async_redact_data(result, TO_REDACT))
     # Errors raised by `pyg90alarm` are treated as non-terminating, just
     # resulting in error response
     except (G90Error, G90TimeoutError) as exc:

--- a/custom_components/gs_alarm/sensor.py
+++ b/custom_components/gs_alarm/sensor.py
@@ -1,18 +1,19 @@
 """
-tbd
+Sensors for `gs_alarm` integration.
 """
 from __future__ import annotations
+from typing import Dict, Any
 import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
 from homeassistant.const import (
+    EntityCategory,
     PERCENTAGE,
 )
 
@@ -36,16 +37,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
 # pylint:disable=too-few-public-methods
 class G90BaseSensor(SensorEntity):
     """
-    tbd
+    Base class for sensors.
     """
-    def __init__(self, hass_data: dict) -> None:
+    def __init__(self, hass_data: Dict[str, Any]) -> None:
         self._hass_data = hass_data
         self._attr_device_info = hass_data['device']
         self._attr_native_value = None
 
-    async def async_update(self):
+    async def async_update(self) -> None:
         """
-        tbd
+        Invoked when HomeAssistant needs to update the sensor, required by base
+        class.
         """
         _LOGGER.debug('Updating state')
 
@@ -53,10 +55,10 @@ class G90BaseSensor(SensorEntity):
 # pylint:disable=too-few-public-methods
 class G90WifiSignal(G90BaseSensor):
     """
-    tbd
+    Sensor for WiFi signal strength.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, hass_data: Dict[str, Any]) -> None:
+        super().__init__(hass_data)
         self._attr_name = f'{DOMAIN}: WiFi Signal'
         self._attr_unique_id = f"{self._hass_data['guid']}_sensor_wifi_signal"
         self._attr_icon = 'mdi:wifi'
@@ -64,9 +66,9 @@ class G90WifiSignal(G90BaseSensor):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    async def async_update(self):
+    async def async_update(self) -> None:
         """
-        tbd
+        Invoked when HomeAssistant needs to update the sensor state.
         """
         await super().async_update()
         # `host_info` of entry data is periodically updated by `G90AlarmPanel`
@@ -76,10 +78,10 @@ class G90WifiSignal(G90BaseSensor):
 
 class G90GsmSignal(G90BaseSensor):
     """
-    tbd
+    Sensor for GSM signal strength.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, hass_data: Dict[str, Any]) -> None:
+        super().__init__(hass_data)
         self._attr_name = f'{DOMAIN}: GSM Signal'
         self._attr_unique_id = f"{self._hass_data['guid']}_sensor_gsm_signal"
         self._attr_icon = 'mdi:signal'
@@ -87,9 +89,9 @@ class G90GsmSignal(G90BaseSensor):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    async def async_update(self):
+    async def async_update(self) -> None:
         """
-        tbd
+        Invoked when HomeAssistant needs to update the sensor state.
         """
         await super().async_update()
         # See above re: how the data is updated

--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -1,8 +1,8 @@
 """
-tbd
+Switches for `gs_alarm` integration.
 """
 from __future__ import annotations
-from typing import Any
+from typing import Any, Dict
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -10,11 +10,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from pyg90alarm.entities.device import G90Device
+
 from .const import DOMAIN
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
-                            async_add_entities: AddEntitiesCallback) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up a config entry."""
     g90switches = []
     for device in await (
@@ -31,9 +35,9 @@ class G90Switch(SwitchEntity):
     # integration, silence the `pylint` for those
     # pylint: disable=abstract-method
     """
-    tbd
+    Switch specific to alarm panel.
     """
-    def __init__(self, device: object, hass_data: dict) -> None:
+    def __init__(self, device: G90Device, hass_data: Dict[str, Any]) -> None:
         self._device = device
         self._state = False
         self._attr_unique_id = (
@@ -46,20 +50,20 @@ class G90Switch(SwitchEntity):
     @property
     def is_on(self) -> bool:
         """
-        tbd
+        Indicates if the switch is active (on).
         """
         return self._state
 
     async def async_turn_on(self, **_kwargs: Any) -> None:
         """
-        tbd
+        Turn on the switch.
         """
         await self._device.turn_on()
         self._state = True
 
     async def async_turn_off(self, **_kwargs: Any) -> None:
         """
-        tbd
+        Turn off the switch.
         """
         await self._device.turn_off()
         self._state = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,11 @@ log_cli_level = "error"
 # Workaround for
 # https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/129
 asyncio_mode = "auto"
+
+[[tool.mypy.overrides]]
+module = "pyg90alarm.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "voluptuous"
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "voluptuous"
 ignore_missing_imports = true
+
+[tool.coverage.run]
+relative_files = true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
-sonar.python.version=3.9, 3.10
+sonar.python.version=3.9, 3.10, 3.11, 3.12
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.pylint.reportPaths=pylint.txt
 sonar.python.flake8.reportPaths=flake8.txt
+sonar.python.mypy.reportPaths=mypy/cobertura.xml
 sonar.coverage.exclusions=tests/**,**/*.json

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -81,8 +81,8 @@ async def test_config_flow_manual_device(hass, mock_g90alarm):
     mock_g90alarm.assert_called_with(host='dummy-manual-host')
 
 
-# pylint: disable=unused-argument
-async def test_config_flow_manual_device_no_ip_addr(hass, mock_g90alarm):
+@pytest.mark.usefixtures('mock_g90alarm')
+async def test_config_flow_manual_device_no_ip_addr(hass):
     """
     Tests config flow wit manual device and omitted input for its hostname/IP
     address.

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     pytest==8.2.0
     pytest-cov==5.0.0
     pytest-unordered==0.6.0
-    mypy==1.11.1
+    mypy[reports]==1.11.1
     pyg90alarm == 1.12.1
 
 allowlist_externals =
@@ -41,7 +41,7 @@ setenv =
 commands =
     flake8 --tee --output-file=flake8.txt custom_components/ tests/
     pylint --output-format=parseable --output=pylint.txt custom_components/ tests/
-    mypy --strict custom_components/
+    mypy --strict --cobertura-xml-report=mypy/ custom_components/
 	# Ensure only traces for in-repository module is processed, not for one
 	# installed by `tox` (see above for more details)
     pytest --cov=custom_components/ --cov-append --cov-report=term-missing -v tests/ []

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
     pytest==8.2.0
     pytest-cov==5.0.0
     pytest-unordered==0.6.0
+    mypy==1.11.1
     pyg90alarm == 1.12.1
 
 allowlist_externals =
@@ -40,6 +41,7 @@ setenv =
 commands =
     flake8 --tee --output-file=flake8.txt custom_components/ tests/
     pylint --output-format=parseable --output=pylint.txt custom_components/ tests/
+    mypy --strict custom_components/
 	# Ensure only traces for in-repository module is processed, not for one
 	# installed by `tox` (see above for more details)
     pytest --cov=custom_components/ --cov-append --cov-report=term-missing -v tests/ []


### PR DESCRIPTION
* Typing hints have been added/adjusted, `tox` now invokes `mypy` to validate the correctness
* `__init__.py`: `DeviceInfo.identifiers` should be initialized with `dict` not `set`, otherwise there will be excessive device appearing on each HASS (re)start
* Coverage reporting has been fixed to store relative paths in the report, mostly for Sonar scanner otherwise it reports the error below:

  ```
  Invalid directory path in 'source' element
  ```