### PR TITLE
feat: Manifest updates. Exception handling. Device title from panel's GUID

### DIFF
--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -63,14 +63,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
         G90WifiStatusSensor | G90GsmStatusSensor | G90BinarySensor
     ] = []
     for sensor in (
-        await hass.data[DOMAIN][entry.entry_id]['client'].get_sensors()
+        hass.data[DOMAIN][entry.entry_id]['panel_sensors']
     ):
         if sensor.enabled:
             g90sensors.append(
                 G90BinarySensor(sensor, hass.data[DOMAIN][entry.entry_id])
             )
-    g90sensors.append(G90WifiStatusSensor(hass.data[DOMAIN][entry.entry_id]))
-    g90sensors.append(G90GsmStatusSensor(hass.data[DOMAIN][entry.entry_id]))
+    g90sensors.append(
+        G90WifiStatusSensor(hass.data[DOMAIN][entry.entry_id])
+    )
+    g90sensors.append(
+        G90GsmStatusSensor(hass.data[DOMAIN][entry.entry_id])
+    )
+
     async_add_entities(g90sensors)
 
 

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -7,8 +7,14 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/hostcc/hass-gs-alarm/blob/master/README.md",
+  "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/hostcc/hass-gs-alarm/issues",
+  "loggers": [
+    "pyg90alarm",
+    "custom_components.gs_alarm"
+  ],
+  "quality_scale": "gold",
   "requirements": [
     "pyg90alarm==1.12.1"
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,13 @@ ignore_missing_imports = true
 module = "voluptuous"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "pytest_homeassistant_custom_component.common"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pytest_homeassistant_custom_component.typing"
+ignore_missing_imports = true
+
 [tool.coverage.run]
 relative_files = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,30 @@
 """
 Pytest configuration and fixtures
 """
+from typing import Iterator
 import asyncio
 from unittest.mock import patch, AsyncMock, PropertyMock
 import pytest
 
+from homeassistant.core import HomeAssistant
+
 import pyg90alarm
+from pyg90alarm import G90Alarm
 
 
 @pytest.fixture(autouse=True)
 # pylint: disable=unused-argument
-def auto_enable_custom_integrations(enable_custom_integrations):
+def auto_enable_custom_integrations(
+    enable_custom_integrations: pytest.FixtureDef[HomeAssistant]
+) -> Iterator[None]:
     """
     Automatically uses `enable_custom_integrations` Homeassistant fixture,
     since it is required for custom integrations to be loaded during tests.
     """
-    yield
+    yield None
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     """
     Configures `pytest`.
     """
@@ -32,7 +38,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def mock_g90alarm(request):
+def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[G90Alarm]:
     """
     Mocks `G90Alarm` instance and its methods relevant to tests.
     """
@@ -61,7 +67,7 @@ def mock_g90alarm(request):
         # information
         mock.return_value.get_host_info = AsyncMock(
             return_value=pyg90alarm.alarm.G90HostInfo(
-                host_guid='Dummy',
+                host_guid='Dummy GUID',
                 product_name='Dummy product',
                 wifi_protocol_version='1.0-test',
                 cloud_protocol_version='1.1-test',

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -6,6 +6,11 @@ from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+   STATE_ALARM_DISARMED,
+   STATE_ALARM_ARMED_AWAY,
+   STATE_ALARM_TRIGGERED,
+)
 
 from pyg90alarm import G90Alarm
 from pyg90alarm.const import G90ArmDisarmTypes
@@ -40,7 +45,7 @@ async def test_alarm_callback(
     # Verify panel state and attributes reflect that
     panel_state = hass.states.get('alarm_control_panel.dummy_guid')
     assert panel_state is not None
-    assert panel_state.state == 'triggered'
+    assert panel_state.state == STATE_ALARM_TRIGGERED
     assert panel_state.attributes.get('changed_by') == 'binary_sensor.dummy_1'
 
     # Simulate the arm callback is triggered
@@ -81,7 +86,7 @@ async def test_arm_callback(
     # Verify panel state reflects that
     panel_state = hass.states.get('alarm_control_panel.dummy_guid')
     assert panel_state is not None
-    assert panel_state.state == 'armed_away'
+    assert panel_state.state == STATE_ALARM_ARMED_AWAY
 
 
 @pytest.mark.g90host_status(
@@ -113,4 +118,4 @@ async def test_disarm_callback(
     # Verify panel state reflects that
     panel_state = hass.states.get('alarm_control_panel.dummy_guid')
     assert panel_state is not None
-    assert panel_state.state == 'disarmed'
+    assert panel_state.state == STATE_ALARM_DISARMED

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,6 +5,9 @@ import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
+from homeassistant.core import HomeAssistant
+
+from pyg90alarm import G90Alarm
 from pyg90alarm.const import G90ArmDisarmTypes
 
 from custom_components.gs_alarm.const import DOMAIN
@@ -13,7 +16,9 @@ from custom_components.gs_alarm.const import DOMAIN
 @pytest.mark.g90host_status(
     result=G90ArmDisarmTypes.DISARM
 )
-async def test_alarm_callback(hass, mock_g90alarm):
+async def test_alarm_callback(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests the alarm panel changes its state upon alarm callback is triggered.
     """
@@ -25,7 +30,6 @@ async def test_alarm_callback(hass, mock_g90alarm):
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-
     await hass.async_block_till_done()
 
     # Simulate the alarm callback is triggered
@@ -34,7 +38,8 @@ async def test_alarm_callback(hass, mock_g90alarm):
     )
 
     # Verify panel state and attributes reflect that
-    panel_state = hass.states.get('alarm_control_panel.dummy')
+    panel_state = hass.states.get('alarm_control_panel.dummy_guid')
+    assert panel_state is not None
     assert panel_state.state == 'triggered'
     assert panel_state.attributes.get('changed_by') == 'binary_sensor.dummy_1'
 
@@ -43,14 +48,17 @@ async def test_alarm_callback(hass, mock_g90alarm):
         G90ArmDisarmTypes.ARM_AWAY
     )
     # Verify `changed_by` attribute has been reset
-    panel_state = hass.states.get('alarm_control_panel.dummy')
+    panel_state = hass.states.get('alarm_control_panel.dummy_guid')
+    assert panel_state is not None
     assert panel_state.attributes.get('changed_by') is None
 
 
 @pytest.mark.g90host_status(
     result=G90ArmDisarmTypes.DISARM
 )
-async def test_arm_callback(hass, mock_g90alarm):
+async def test_arm_callback(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests the alarm panel changes its state upon arm callback is triggered for
     arming away.
@@ -63,7 +71,6 @@ async def test_arm_callback(hass, mock_g90alarm):
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-
     await hass.async_block_till_done()
 
     # Simulate the arm callback is triggered
@@ -72,14 +79,17 @@ async def test_arm_callback(hass, mock_g90alarm):
     )
 
     # Verify panel state reflects that
-    panel_state = hass.states.get('alarm_control_panel.dummy')
+    panel_state = hass.states.get('alarm_control_panel.dummy_guid')
+    assert panel_state is not None
     assert panel_state.state == 'armed_away'
 
 
 @pytest.mark.g90host_status(
     result=G90ArmDisarmTypes.ARM_AWAY
 )
-async def test_disarm_callback(hass, mock_g90alarm):
+async def test_disarm_callback(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests the alarm panel changes its state upon arm callback is triggered for
     disarming.
@@ -101,5 +111,6 @@ async def test_disarm_callback(hass, mock_g90alarm):
     )
 
     # Verify panel state reflects that
-    panel_state = hass.states.get('alarm_control_panel.dummy')
+    panel_state = hass.states.get('alarm_control_panel.dummy_guid')
+    assert panel_state is not None
     assert panel_state.state == 'disarmed'

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,9 +3,11 @@ Tests config flow for the custom component.
 """
 import pytest
 
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.config_entries import ConfigEntry
 
+from pyg90alarm import G90Alarm
 from custom_components.gs_alarm.const import DOMAIN
 
 
@@ -17,7 +19,9 @@ from custom_components.gs_alarm.const import DOMAIN
         'port': 4321,
     }
 ])
-async def test_config_flow_discovered_devices(hass, mock_g90alarm):
+async def test_config_flow_discovered_devices(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests config flow with single discovered device.
     """
@@ -45,7 +49,9 @@ async def test_config_flow_discovered_devices(hass, mock_g90alarm):
     mock_g90alarm.assert_called_with(host='dummy-discovered-host')
 
 
-async def test_config_flow_manual_device(hass, mock_g90alarm):
+async def test_config_flow_manual_device(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests config flow with no discovered and single manually added device.
     """
@@ -82,7 +88,9 @@ async def test_config_flow_manual_device(hass, mock_g90alarm):
 
 
 @pytest.mark.usefixtures('mock_g90alarm')
-async def test_config_flow_manual_device_no_ip_addr(hass):
+async def test_config_flow_manual_device_no_ip_addr(
+    hass: HomeAssistant
+) -> None:
     """
     Tests config flow wit manual device and omitted input for its hostname/IP
     address.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,15 +6,23 @@ from pytest_unordered import unordered
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
+from pytest_homeassistant_custom_component.typing import (
+    ClientSessionGenerator
+)
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.helpers.device_registry as dr
+
+from pyg90alarm import G90Alarm
 from pyg90alarm.exceptions import G90Error
 
 from custom_components.gs_alarm.const import DOMAIN
 
 
 @pytest.mark.usefixtures('mock_g90alarm')
-async def test_diagnostics(hass, hass_client):
+async def test_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """
     Verifies diagnostics are successfully generated.
     """
@@ -73,7 +81,10 @@ async def test_diagnostics(hass, hass_client):
     assert list(data['alarm_panel'].keys()) == expected_alarm_panel_keys
 
 
-async def test_diagnostics_exception(hass, hass_client, mock_g90alarm):
+async def test_diagnostics_exception(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator,
+    mock_g90alarm: G90Alarm
+) -> None:
     """
     Verify the `pyg90alarm` error doesn't lead to diagnostics resulting in
     internal error sent back to the client.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,212 @@
+"""
+Tests for exception handling by the custom component.
+"""
+from datetime import timedelta
+from unittest.mock import AsyncMock
+import pytest
+
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+   SERVICE_ALARM_ARM_AWAY,
+   SERVICE_ALARM_ARM_HOME,
+   SERVICE_ALARM_DISARM,
+   SERVICE_TURN_ON,
+   SERVICE_TURN_OFF,
+   STATE_ALARM_DISARMED,
+   STATE_UNKNOWN,
+   STATE_OFF,
+)
+from homeassistant.components.alarm_control_panel.const import (
+    DOMAIN as ALARM_DOMAIN
+)
+from homeassistant.components.switch.const import (
+    DOMAIN as SWITCH_DOMAIN
+)
+
+from pyg90alarm import G90Alarm
+from pyg90alarm.exceptions import G90TimeoutError, G90Error
+from custom_components.gs_alarm.const import DOMAIN
+
+
+@pytest.mark.parametrize(
+    "failed_g90_method,simulated_error,expected_entry_state", [
+        ('get_host_info', G90TimeoutError, ConfigEntryState.SETUP_RETRY),
+        ('get_host_info', G90Error, ConfigEntryState.SETUP_ERROR),
+        ('get_devices', G90TimeoutError, ConfigEntryState.SETUP_RETRY),
+        ('get_devices', G90Error, ConfigEntryState.SETUP_ERROR),
+        ('get_sensors', G90TimeoutError, ConfigEntryState.SETUP_RETRY),
+        ('get_sensors', G90Error, ConfigEntryState.SETUP_ERROR),
+        # The simulated errors below will trigger inside entry update listener,
+        # and won't result in state being error
+        (
+            'start_simulating_alerts_from_history',
+            G90Error, ConfigEntryState.LOADED
+        ),
+        (
+            'stop_simulating_alerts_from_history',
+            G90Error, ConfigEntryState.LOADED
+        ),
+    ]
+)
+async def test_setup_entry_exception(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm, failed_g90_method: str,
+    simulated_error: Exception, expected_entry_state: ConfigEntryState
+) -> None:
+    """
+    Tests the custom integration properly handles exceptions during the setup.
+    """
+    # Simulate the error in specific `G90Alarm` method
+    getattr(
+       mock_g90alarm.return_value, failed_g90_method
+    ).side_effect = simulated_error
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={
+            # Required for `G90Alarm.stop_simulating_alerts_from_history()`
+            # method to be called
+            'simulate_alerts_from_history': False
+        },
+        entry_id="test-exc"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify the entity is in expected state
+    assert config_entry.state == expected_entry_state
+
+
+async def test_alarm_panel_state_update_exception(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
+    """
+    Tests the custom integration properly handles exceptions when updating the
+    state.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test-exc"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+
+    # Simulate the error in `G90Alarm.get_host_info()` method that is used to
+    # fetch panel's state. The simulated error is set after entry is loaded, so
+    # that execution comes to state update
+    mock_g90alarm.return_value.get_host_info.side_effect = G90Error
+
+    # Simulate some time has passed for HomeAssistant to invoke
+    # `async_update()` for components
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
+
+    # Verify the panel's state is unknown
+    panel_state = hass.states.get('alarm_control_panel.dummy_guid')
+    assert panel_state is not None
+    assert panel_state.state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize("failed_service,failed_g90_method", [
+    (SERVICE_ALARM_DISARM, 'disarm'),
+    (SERVICE_ALARM_ARM_HOME, 'arm_home'),
+    (SERVICE_ALARM_ARM_AWAY, 'arm_away'),
+])
+@pytest.mark.parametrize("simulated_error", [
+    G90Error,
+    G90TimeoutError,
+])
+async def test_alarm_panel_service_exception(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm,
+    failed_service: str, failed_g90_method: str, simulated_error: Exception
+) -> None:
+    """
+    Tests the custom integration properly handles exceptions during service
+    calls to alarm panel.
+    """
+    # Simulate the error in specific `G90Alarm` method
+    getattr(
+        mock_g90alarm.return_value, failed_g90_method
+    ).side_effect = simulated_error
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test-exc"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity = hass.states.get('alarm_control_panel.dummy_guid')
+    assert entity is not None
+    # Perform the call
+    await hass.services.async_call(
+        ALARM_DOMAIN, failed_service,
+        {'entity_id': entity.entity_id},
+        blocking=True
+    )
+
+    # Verify the panel's state is left unchanged - `mock_g90alarm` simulates
+    # the panel is disarmed during initial setup
+    assert entity.state == STATE_ALARM_DISARMED
+
+
+@pytest.mark.parametrize("failed_service,failed_g90_method", [
+    (SERVICE_TURN_ON, 'turn_on'),
+    (SERVICE_TURN_OFF, 'turn_off'),
+    (SERVICE_TURN_ON, None),
+    (SERVICE_TURN_OFF, None),
+])
+@pytest.mark.parametrize("simulated_error", [
+    G90Error,
+    G90TimeoutError,
+])
+async def test_switch_service_exception(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm,
+    failed_service: str, failed_g90_method: str, simulated_error: Exception
+) -> None:
+    """
+    Tests the custom integration properly handles exceptions during service
+    calls to switches of the alarm panel.
+    """
+    if failed_g90_method:
+        # Simulate the error in specific `G90Alarm` method
+        setattr(
+            (await mock_g90alarm.return_value.get_devices())[0],
+            failed_g90_method,
+            AsyncMock(side_effect=simulated_error)
+        )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test-exc"
+    )
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity = hass.states.get('switch.dummy_switch_1')
+    assert entity is not None
+    await hass.services.async_call(
+        SWITCH_DOMAIN, failed_service,
+        {'entity_id': entity.entity_id},
+        blocking=True
+    )
+
+    # Verify the switch's state is left unchanged - `G90Switch` initializes it
+    # to off
+    assert entity.state == STATE_OFF

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,14 +9,18 @@ from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 
+from pyg90alarm import G90Alarm
 from custom_components.gs_alarm.const import DOMAIN
 
 
-async def test_setup_unload_and_reload_entry_afresh(hass, mock_g90alarm):
+async def test_setup_unload_and_reload_entry_afresh(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests the custom integration load and then unloads properly, simulating it
     just been added to HASS with no options persisted previously.
@@ -35,6 +39,8 @@ async def test_setup_unload_and_reload_entry_afresh(hass, mock_g90alarm):
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
     await hass.async_block_till_done()
 
+    assert config_entry.title == 'Dummy GUID'
+
     mock_g90alarm.assert_called_once_with(host='dummy-ip')
 
     # Verify single device has been added
@@ -51,7 +57,7 @@ async def test_setup_unload_and_reload_entry_afresh(hass, mock_g90alarm):
     )
     integration_entity_ids = [x.entity_id for x in integration_entities]
     assert integration_entity_ids == unordered([
-        'alarm_control_panel.dummy',
+        'alarm_control_panel.dummy_guid',
         'binary_sensor.dummy_sensor_1',
         'switch.dummy_switch_1',
         'sensor.gs_alarm_wifi_signal',
@@ -73,13 +79,15 @@ async def test_setup_unload_and_reload_entry_afresh(hass, mock_g90alarm):
         assert re.search(r'^(sensor|binary_sensor)\..+$', sensor.extra_data)
 
     # Unload the integration
-    await hass.config_entries.async_unload(config_entry.entry_id, DOMAIN)
+    await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
     # Verify the component cleaned up its data upon unloading
     assert not hass.data[DOMAIN]
 
 
-async def test_setup_entry_with_persisted_options(hass, mock_g90alarm):
+async def test_setup_entry_with_persisted_options(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests the custom integration loads properly, simulating there are some
     options persisted (integration has been added to HASS and configured).

--- a/tests/test_option_flow.py
+++ b/tests/test_option_flow.py
@@ -3,15 +3,19 @@ Tests for option (configure) flow for the custom component.
 """
 from unittest.mock import PropertyMock
 
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
 
+from pyg90alarm import G90Alarm
 from custom_components.gs_alarm.const import DOMAIN
 
 
-async def test_config_flow_options(hass, mock_g90alarm):
+async def test_config_flow_options(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests options (configure) flow for the component with correct inputs.
     """
@@ -63,7 +67,9 @@ async def test_config_flow_options(hass, mock_g90alarm):
         .start_simulating_alerts_from_history.assert_called())
 
 
-async def test_config_flow_options_unsupported_disable(hass, mock_g90alarm):
+async def test_config_flow_options_unsupported_disable(
+    hass: HomeAssistant, mock_g90alarm: G90Alarm
+) -> None:
     """
     Tests options (configure) flow for the component where sensor attempted to
     disable and it isn't supported.

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ setenv =
 commands =
     flake8 --tee --output-file=flake8.txt custom_components/ tests/
     pylint --output-format=parseable --output=pylint.txt custom_components/ tests/
-    mypy --strict --cobertura-xml-report=mypy/ custom_components/
+    mypy --strict --cobertura-xml-report=mypy/ custom_components/ tests/
 	# Ensure only traces for in-repository module is processed, not for one
 	# installed by `tox` (see above for more details)
     pytest --cov=custom_components/ --cov-append --cov-report=term-missing -v tests/ []


### PR DESCRIPTION
* Added exception handling during component's setup and operations on entities, as per HASS development guidelines
* Manifest has been updated for:
  * Integration class being `device` (it is `hub` by default, making multiple devices under same config entry, while those should be separate ones)
  * The quiality marked as `gold` - it is believed the [requirements to the level](https://developers.home-assistant.io/docs/integration_quality_scale_index/#gold-) have been fulfilled
  * Loggers have been enlisted, so that `Enable debug logging` will properly set the levels only on those
* Typing fixes to tests