### PR TITLE
fix: Retain state of alarm panel despite of errors updating it

### DIFF
--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -142,8 +142,10 @@ class G90AlarmPanel(AlarmControlPanelEntity):
                 await self._hass_data['client'].get_host_info()
             )
         except (G90Error, G90TimeoutError) as exc:
+            # Log the error but retain the state, otherwise it might get noisy
+            # re: changing it between `unknown` and last state - the panel is
+            # known of leading to protocol errors somewhat often
             _LOGGER.error('Error updating state of alarm panel: %s', repr(exc))
-            self._state = STATE_UNKNOWN
 
     @property
     def state(self) -> str:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
    SERVICE_TURN_ON,
    SERVICE_TURN_OFF,
    STATE_ALARM_DISARMED,
-   STATE_UNKNOWN,
    STATE_OFF,
 )
 from homeassistant.components.alarm_control_panel.const import (
@@ -113,7 +112,7 @@ async def test_alarm_panel_state_update_exception(
     # Verify the panel's state is unknown
     panel_state = hass.states.get('alarm_control_panel.dummy_guid')
     assert panel_state is not None
-    assert panel_state.state == STATE_UNKNOWN
+    assert panel_state.state == STATE_ALARM_DISARMED
 
 
 @pytest.mark.parametrize("failed_service,failed_g90_method", [


### PR DESCRIPTION
* `async_update` method of `alarm_control_panel` platform now retains previously known panel state, instead of going to `unkwnown`. The behavior of going to `unknown` is introduced by 1.16.0 and might get noisy re: changing it between `unknown` and last state - the panel is known of leading to protocol errors somewhat often