### PR TITLE
fix: [Github workflow] Proper test for redundant `release` workflow runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,12 +41,13 @@ jobs:
 
       - name: Set version in manifest and commit that
         uses: maxgfr/github-change-json@v0.0.26
-        # Only perform release-related actions if new version is generated, do
-        # nothing otherwise - primiry use case to prevent another run of the
-        # workflow triggered when manifest is updated (see below)
-        if: >-
-            steps.version.outputs.next !=
-            steps.version.outputs.current
+        # Only perform release-related actions if new version is generated
+        # (check is done between `nextStrict` and `current` versions, since
+        # `release-action` below uses the former thus creating the tags after
+        # the version) , do nothing otherwise - primary use case to prevent
+        # another run of the workflow triggered when manifest is updated (see
+        # below)
+        if: steps.version.outputs.nextStrict != steps.version.outputs.current
         with:
           key: version
           value: ${{ steps.version.outputs.nextStrict }}
@@ -54,9 +55,7 @@ jobs:
 
       - name: Commit updated manifest
         # See comment above
-        if: >-
-            steps.version.outputs.next !=
-            steps.version.outputs.current
+        if: steps.version.outputs.nextStrict != steps.version.outputs.current
         run: |
           git config --local user.email \
             "github-actions[bot]@users.noreply.github.com"
@@ -68,9 +67,7 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         # See comment above
-        if: >-
-            steps.version.outputs.next !=
-            steps.version.outputs.current
+        if: steps.version.outputs.nextStrict != steps.version.outputs.current
         with:
           # SSH (deploy) key allows to bypass branch protection on default
           # branch
@@ -80,9 +77,7 @@ jobs:
       - name: Create release
         uses: ncipollo/release-action@v1
         # See comment above
-        if: >-
-            steps.version.outputs.next !=
-            steps.version.outputs.current
+        if: steps.version.outputs.nextStrict != steps.version.outputs.current
         with:
           # Base the release off of the tip of default branch
           commit: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
* `release.yaml` now uses proper check to skip redundant runs - check is done between `nextStrict` and `current` versions, since `release-action` uses the former thus creating the tags after the version