### PR TITLE
chore: Log entity ID along with errors

### DIFF
--- a/custom_components/gs_alarm/__init__.py
+++ b/custom_components/gs_alarm/__init__.py
@@ -100,8 +100,10 @@ async def options_update_listener(
                 await g90_client.stop_simulating_alerts_from_history()
         except (G90Error, G90TimeoutError) as exc:
             _LOGGER.error(
-                'Error %s simulate device alerts from history: %s',
+                "Error %s simulate device alerts from history"
+                " for panel '%s': %s",
                 'enabling' if simulate_alerts_from_history else 'disabling',
+                entry.title,
                 repr(exc)
             )
 

--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -145,7 +145,11 @@ class G90AlarmPanel(AlarmControlPanelEntity):
             # Log the error but retain the state, otherwise it might get noisy
             # re: changing it between `unknown` and last state - the panel is
             # known of leading to protocol errors somewhat often
-            _LOGGER.error('Error updating state of alarm panel: %s', repr(exc))
+            _LOGGER.error(
+                "Error updating state of alarm panel '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )
 
     @property
     def state(self) -> str:
@@ -161,7 +165,11 @@ class G90AlarmPanel(AlarmControlPanelEntity):
         except (G90Error, G90TimeoutError) as exc:
             # Log the error, the state is not altered since `async_update()`
             # should read back the previous state unchanged
-            _LOGGER.error('Error disarming: %s', repr(exc))
+            _LOGGER.error(
+                "Error disarming panel '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )
 
     async def async_alarm_arm_home(self, _code: str | None = None) -> None:
         """Send arm home command."""
@@ -169,7 +177,11 @@ class G90AlarmPanel(AlarmControlPanelEntity):
             await self._hass_data['client'].arm_home()
         except (G90Error, G90TimeoutError) as exc:
             # See comment above
-            _LOGGER.error('Error arming home: %s', repr(exc))
+            _LOGGER.error(
+                "Error arming panel '%s' home: %s",
+                self.unique_id,
+                repr(exc)
+            )
 
     async def async_alarm_arm_away(self, _code: str | None = None) -> None:
         """Send arm away command."""
@@ -177,4 +189,8 @@ class G90AlarmPanel(AlarmControlPanelEntity):
             await self._hass_data['client'].arm_away()
         except (G90Error, G90TimeoutError) as exc:
             # See comment above
-            _LOGGER.error('Error arming away: %s', repr(exc))
+            _LOGGER.error(
+                "Error arming panel '%s' away: %s",
+                self.unique_id,
+                repr(exc)
+            )

--- a/custom_components/gs_alarm/diagnostics.py
+++ b/custom_components/gs_alarm/diagnostics.py
@@ -99,6 +99,9 @@ async def async_get_device_diagnostics(
     # Errors raised by `pyg90alarm` are treated as non-terminating, just
     # resulting in error response
     except (G90Error, G90TimeoutError) as exc:
-        msg = f'Unable to gather diagnostics data: {repr(exc)}'
+        msg = (
+            "Unable to gather diagnostics data for"
+            f" panel '{entry.title}': {repr(exc)}"
+        )
         _LOGGER.error(msg)
         return {'error': msg}

--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -70,7 +70,11 @@ class G90Switch(SwitchEntity):
         except (G90Error, G90TimeoutError) as exc:
             # State isn't set to STATE_UNKNOWN since the panel doesn't support
             # reading it back
-            _LOGGER.error('Error turning on the switch: %s', repr(exc))
+            _LOGGER.error(
+                "Error turning on the switch '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )
         else:
             # State is only updated upon successful command execution
             self._state = True
@@ -83,7 +87,11 @@ class G90Switch(SwitchEntity):
             await self._device.turn_off()
         except (G90Error, G90TimeoutError) as exc:
             # See comment above
-            _LOGGER.error('Error turning off the switch: %s', repr(exc))
+            _LOGGER.error(
+                "Error turning off the switch '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )
         else:
             # See comment above
             self._state = False

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -111,5 +111,7 @@ async def test_diagnostics_exception(
     response_dict = await response.json()
     data = response_dict.get('data')
     assert data == {
-        'error': 'Unable to gather diagnostics data: G90Error()'
+        'error':
+            "Unable to gather diagnostics data for"
+            " panel 'Dummy GUID': G90Error()"
     }


### PR DESCRIPTION
* All errors reported by the component should now have corresponding entity ID logged for easy of correlating those, when multiple devices are considered