### PR TITLE
feat: Support typing hints from `pyg90alarm` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+build/
+dist/
+*.egg-info/
+*.egg
+*.py[cod]
+__pycache__/
+.venv/
+*.so
+*~
+.tox
+.cache
+.DS_Store
+# Tests related
+flake8.txt
+pylint.txt
+.coverage*
+coverage.xml
+.mypy_cache/
+mypy/

--- a/custom_components/gs_alarm/config_flow.py
+++ b/custom_components/gs_alarm/config_flow.py
@@ -137,10 +137,9 @@ class OptionsFlowHandler(OptionsFlow):
         Manage the options.
         """
         # Attempt to retrieve `G90Alarm()` instance from integration data
-        g90_client = (
-            self.hass.data[DOMAIN]
-            .get(self.config_entry.entry_id, {})
-            .get('client', None)
+        g90_client = getattr(
+            self.hass.data[DOMAIN].get(self.config_entry.entry_id, None),
+            'client', None
         )
 
         schema = {

--- a/custom_components/gs_alarm/sensor.py
+++ b/custom_components/gs_alarm/sensor.py
@@ -2,7 +2,7 @@
 Sensors for `gs_alarm` integration.
 """
 from __future__ import annotations
-from typing import Dict, Any
+from typing import TYPE_CHECKING
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -20,6 +20,8 @@ from homeassistant.const import (
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+if TYPE_CHECKING:
+    from . import GsAlarmData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,9 +41,9 @@ class G90BaseSensor(SensorEntity):
     """
     Base class for sensors.
     """
-    def __init__(self, hass_data: Dict[str, Any]) -> None:
+    def __init__(self, hass_data: GsAlarmData) -> None:
         self._hass_data = hass_data
-        self._attr_device_info = hass_data['device']
+        self._attr_device_info = hass_data.device
         self._attr_native_value = None
 
     async def async_update(self) -> None:
@@ -57,10 +59,10 @@ class G90WifiSignal(G90BaseSensor):
     """
     Sensor for WiFi signal strength.
     """
-    def __init__(self, hass_data: Dict[str, Any]) -> None:
+    def __init__(self, hass_data: GsAlarmData) -> None:
         super().__init__(hass_data)
         self._attr_name = f'{DOMAIN}: WiFi Signal'
-        self._attr_unique_id = f"{self._hass_data['guid']}_sensor_wifi_signal"
+        self._attr_unique_id = f"{self._hass_data.guid}_sensor_wifi_signal"
         self._attr_icon = 'mdi:wifi'
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -72,7 +74,7 @@ class G90WifiSignal(G90BaseSensor):
         """
         await super().async_update()
         # `host_info` of entry data is periodically updated by `G90AlarmPanel`
-        host_info = self._hass_data['host_info']
+        host_info = self._hass_data.host_info
         self._attr_native_value = host_info.wifi_signal_level
 
 
@@ -80,10 +82,10 @@ class G90GsmSignal(G90BaseSensor):
     """
     Sensor for GSM signal strength.
     """
-    def __init__(self, hass_data: Dict[str, Any]) -> None:
+    def __init__(self, hass_data: GsAlarmData) -> None:
         super().__init__(hass_data)
         self._attr_name = f'{DOMAIN}: GSM Signal'
-        self._attr_unique_id = f"{self._hass_data['guid']}_sensor_gsm_signal"
+        self._attr_unique_id = f"{self._hass_data.guid}_sensor_gsm_signal"
         self._attr_icon = 'mdi:signal'
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -95,5 +97,5 @@ class G90GsmSignal(G90BaseSensor):
         """
         await super().async_update()
         # See above re: how the data is updated
-        host_info = self._hass_data['host_info']
+        host_info = self._hass_data.host_info
         self._attr_native_value = host_info.gsm_signal_level

--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -2,7 +2,7 @@
 Switches for `gs_alarm` integration.
 """
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any, TYPE_CHECKING
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -11,12 +11,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from pyg90alarm.entities.device import G90Device
-from pyg90alarm.exceptions import (
-    G90Error, G90TimeoutError
+from pyg90alarm import (
+    G90Device, G90Error, G90TimeoutError
 )
 
 from .const import DOMAIN
+if TYPE_CHECKING:
+    from . import GsAlarmData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ async def async_setup_entry(
     """Set up a config entry."""
     g90switches = []
     for device in (
-        hass.data[DOMAIN][entry.entry_id]['panel_devices']
+        hass.data[DOMAIN][entry.entry_id].panel_devices
     ):
         g90switches.append(
             G90Switch(device, hass.data[DOMAIN][entry.entry_id])
@@ -44,14 +45,14 @@ class G90Switch(SwitchEntity):
     """
     Switch specific to alarm panel.
     """
-    def __init__(self, device: G90Device, hass_data: Dict[str, Any]) -> None:
+    def __init__(self, device: G90Device, hass_data: GsAlarmData) -> None:
         self._device = device
         self._state = False
         self._attr_unique_id = (
-            f"{hass_data['guid']}_switch_{device.index}_{device.subindex + 1}"
+            f"{hass_data.guid}_switch_{device.index}_{device.subindex + 1}"
         )
         self._attr_name = device.name
-        self._attr_device_info = hass_data['device']
+        self._attr_device_info = hass_data.device
         self._hass_data = hass_data
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,6 @@ log_cli_level = "error"
 asyncio_mode = "auto"
 
 [[tool.mypy.overrides]]
-module = "pyg90alarm.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = "voluptuous"
 ignore_missing_imports = true
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,9 @@
+flake8==7.0.0
+pylint==3.0.3
+coverage==7.5.0
+pytest-homeassistant-custom-component==0.13.132
+pytest==8.2.0
+pytest-cov==5.0.0
+pytest-unordered==0.6.0
+mypy[reports]==1.11.1
+pyg90alarm==1.14.0

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -12,17 +12,17 @@ from homeassistant.const import (
    STATE_ALARM_TRIGGERED,
 )
 
-from pyg90alarm import G90Alarm
-from pyg90alarm.const import G90ArmDisarmTypes
+from pyg90alarm import G90ArmDisarmTypes
 
 from custom_components.gs_alarm.const import DOMAIN
+from .conftest import AlarmMockT
 
 
 @pytest.mark.g90host_status(
     result=G90ArmDisarmTypes.DISARM
 )
 async def test_alarm_callback(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests the alarm panel changes its state upon alarm callback is triggered.
@@ -62,7 +62,7 @@ async def test_alarm_callback(
     result=G90ArmDisarmTypes.DISARM
 )
 async def test_arm_callback(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests the alarm panel changes its state upon arm callback is triggered for
@@ -93,7 +93,7 @@ async def test_arm_callback(
     result=G90ArmDisarmTypes.ARM_AWAY
 )
 async def test_disarm_callback(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests the alarm panel changes its state upon arm callback is triggered for

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,8 +7,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.config_entries import ConfigEntry
 
-from pyg90alarm import G90Alarm
 from custom_components.gs_alarm.const import DOMAIN
+from .conftest import AlarmMockT
 
 
 # Simulate single device discovered
@@ -20,7 +20,7 @@ from custom_components.gs_alarm.const import DOMAIN
     }
 ])
 async def test_config_flow_discovered_devices(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests config flow with single discovered device.
@@ -50,7 +50,7 @@ async def test_config_flow_discovered_devices(
 
 
 async def test_config_flow_manual_device(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests config flow with no discovered and single manually added device.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -13,10 +13,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.helpers.device_registry as dr
 
-from pyg90alarm import G90Alarm
-from pyg90alarm.exceptions import G90Error
+from pyg90alarm import G90Error
 
 from custom_components.gs_alarm.const import DOMAIN
+from .conftest import AlarmMockT
 
 
 @pytest.mark.usefixtures('mock_g90alarm')
@@ -83,7 +83,7 @@ async def test_diagnostics(
 
 async def test_diagnostics_exception(
     hass: HomeAssistant, hass_client: ClientSessionGenerator,
-    mock_g90alarm: G90Alarm
+    mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Verify the `pyg90alarm` error doesn't lead to diagnostics resulting in

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -28,9 +28,9 @@ from homeassistant.components.switch.const import (
     DOMAIN as SWITCH_DOMAIN
 )
 
-from pyg90alarm import G90Alarm
-from pyg90alarm.exceptions import G90TimeoutError, G90Error
+from pyg90alarm import G90TimeoutError, G90Error
 from custom_components.gs_alarm.const import DOMAIN
+from .conftest import AlarmMockT
 
 
 @pytest.mark.parametrize(
@@ -54,7 +54,7 @@ from custom_components.gs_alarm.const import DOMAIN
     ]
 )
 async def test_setup_entry_exception(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm, failed_g90_method: str,
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT, failed_g90_method: str,
     simulated_error: Exception, expected_entry_state: ConfigEntryState
 ) -> None:
     """
@@ -84,7 +84,7 @@ async def test_setup_entry_exception(
 
 
 async def test_alarm_panel_state_update_exception(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests the custom integration properly handles exceptions when updating the
@@ -125,7 +125,7 @@ async def test_alarm_panel_state_update_exception(
     G90TimeoutError,
 ])
 async def test_alarm_panel_service_exception(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm,
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT,
     failed_service: str, failed_g90_method: str, simulated_error: Exception
 ) -> None:
     """
@@ -172,7 +172,7 @@ async def test_alarm_panel_service_exception(
     G90TimeoutError,
 ])
 async def test_switch_service_exception(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm,
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT,
     failed_service: str, failed_g90_method: str, simulated_error: Exception
 ) -> None:
     """

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,12 +14,12 @@ from homeassistant.util import dt
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 
-from pyg90alarm import G90Alarm
 from custom_components.gs_alarm.const import DOMAIN
+from .conftest import AlarmMockT
 
 
 async def test_setup_unload_and_reload_entry_afresh(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests the custom integration load and then unloads properly, simulating it
@@ -86,7 +86,7 @@ async def test_setup_unload_and_reload_entry_afresh(
 
 
 async def test_setup_entry_with_persisted_options(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests the custom integration loads properly, simulating there are some

--- a/tests/test_option_flow.py
+++ b/tests/test_option_flow.py
@@ -9,12 +9,12 @@ from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
 
-from pyg90alarm import G90Alarm
 from custom_components.gs_alarm.const import DOMAIN
+from .conftest import AlarmMockT
 
 
 async def test_config_flow_options(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests options (configure) flow for the component with correct inputs.
@@ -68,7 +68,7 @@ async def test_config_flow_options(
 
 
 async def test_config_flow_options_unsupported_disable(
-    hass: HomeAssistant, mock_g90alarm: G90Alarm
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
 ) -> None:
     """
     Tests options (configure) flow for the component where sensor attempted to

--- a/tox.ini
+++ b/tox.ini
@@ -20,15 +20,7 @@ skipsdist=true
 
 [testenv]
 deps =
-    flake8==7.0.0
-    pylint==3.0.3
-    coverage==7.5.0
-    pytest-homeassistant-custom-component==0.13.132
-    pytest==8.2.0
-    pytest-cov==5.0.0
-    pytest-unordered==0.6.0
-    mypy[reports]==1.11.1
-    pyg90alarm == 1.13.0
+    -rrequirements_dev.txt
 
 allowlist_externals =
 	cat


### PR DESCRIPTION
* Component-specific data now has dedicated type (`GsAlarmData` dataclass) to support proper typing hints
* Enable typing hints from `pyg90alarm` package provided starting from 1.14.0
* Tests have been updated to use correct type for `G90Alarm` mock, should be one aliased to `AsyncMock`
* Diagnostics now leverage `_asdict()` method for sensors/devices, making `format_g90_sensor_device()` function redundant
* Development requirements are now in separate `requirements_dev.txt` file to allow tools other then `tox` to establish proper environment