### PR TITLE
fix: Bump `pyg90alarm` version

### DIFF
--- a/custom_components/gs_alarm/diagnostics.py
+++ b/custom_components/gs_alarm/diagnostics.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 # Redact the properties could contain sensitive information
 TO_REDACT = [
     'host_guid', 'host_phone_number', 'ip_addr', 'serial_number', 'name',
-    'title', 'identifiers', 'extra_data',
+    'title', 'identifiers', 'extra_data', 'sensor_name'
 ]
 
 

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -16,7 +16,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "pyg90alarm==1.13.0"
+    "pyg90alarm==1.14.0"
   ],
   "version": "1.18.0"
 }


### PR DESCRIPTION
* Unfortunately update to `pyg90alarm` has been missing from https://github.com/hostcc/hass-gs-alarm/pull/39, that has been corrected
* Diagnostics: redact sensor names