### PR TITLE
feat: Extra attributes for binary sensors

### DIFF
--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -16,7 +16,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "pyg90alarm==1.14.0"
+    "pyg90alarm==1.15.1"
   ],
   "version": "1.18.1"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ pytest==8.2.0
 pytest-cov==5.0.0
 pytest-unordered==0.6.0
 mypy[reports]==1.11.1
-pyg90alarm==1.14.0
+pyg90alarm==1.15.1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -66,6 +66,14 @@ async def test_setup_unload_and_reload_entry_afresh(
         'binary_sensor.gs_alarm_gsm_status'
     ])
 
+    # Verify binary sensor has expected extra attributes
+    dummy_sensor_1 = hass.states.get('binary_sensor.dummy_sensor_1')
+    assert dummy_sensor_1 is not None
+    assert 'wireless' in dummy_sensor_1.attributes
+    assert 'panel_sensor_number' in dummy_sensor_1.attributes
+    assert 'protocol' in dummy_sensor_1.attributes
+    assert 'flags' in dummy_sensor_1.attributes
+
     # Verify options haven't been propagated to `G90Alarm` instance
     mock_g90alarm.return_value.sms_alert_when_armed.assert_not_called()
     (


### PR DESCRIPTION
* Binary sensors have got extra attributes over sensor characteristics, useful for troubleshooting to identify sensor type and its number as panel reports it. The attributes include flag indicating if sensor is low on battery, applicable to wireless sensors only