### PR TITLE
feat: Update test mocks, addtesting with Python 3.13

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,6 +35,8 @@ jobs:
           - os: ubuntu-latest
             python: '3.12'
             toxenv: py
+          - os: ubuntu-latest
+            python: '3.13'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the code

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,6 +37,7 @@ jobs:
             toxenv: py
           - os: ubuntu-latest
             python: '3.13'
+            toxenv: py
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the code

--- a/custom_components/gs_alarm/config_flow.py
+++ b/custom_components/gs_alarm/config_flow.py
@@ -142,7 +142,10 @@ class OptionsFlowHandler(OptionsFlow):
             'client', None
         )
 
-        schema = {
+        schema: dict[
+            vol.Required | vol.Optional,
+            SelectSelector | BooleanSelector
+        ] = {
             vol.Required(
                 "sms_alert_when_armed",
                 default=self.config_entry.options.get(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,8 @@ log_cli_level = "error"
 # Workaround for
 # https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/129
 asyncio_mode = "auto"
-
-[[tool.mypy.overrides]]
-module = "voluptuous"
-ignore_missing_imports = true
+# Introduced by `pytest-asyncio` recently
+asyncio_default_fixture_loop_scope = "function"
 
 [[tool.mypy.overrides]]
 module = "pytest_homeassistant_custom_component.common"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,9 @@
 flake8==7.0.0
 pylint==3.0.3
-coverage==7.5.0
-pytest-homeassistant-custom-component==0.13.132
-pytest==8.2.0
+coverage==7.6.1
+pytest-homeassistant-custom-component==0.13.174
+pytest==8.3.3
 pytest-cov==5.0.0
-pytest-unordered==0.6.0
+pytest-unordered==0.6.1
 mypy[reports]==1.11.1
-pyg90alarm==1.15.1
+pyg90alarm==1.16.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Python 3.10 is no longer supported by HASS, see
 # https://github.com/home-assistant/core/pull/98640
-envlist = py{312}
+envlist = py{312,313}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and
@@ -22,9 +22,6 @@ skipsdist=true
 deps =
     -rrequirements_dev.txt
 
-allowlist_externals =
-	cat
-
 setenv =
 	# Allow tests to import the custom compontent using
 	# `custom_components.<...>` names
@@ -32,12 +29,8 @@ setenv =
 
 commands =
     flake8 --tee --output-file=flake8.txt custom_components/ tests/
-    pylint --output-format=parseable --output=pylint.txt custom_components/ tests/
+    pylint --output-format=parseable:pylint.txt custom_components/ tests/
     mypy --strict --cobertura-xml-report=mypy/ custom_components/ tests/
 	# Ensure only traces for in-repository module is processed, not for one
 	# installed by `tox` (see above for more details)
     pytest --cov=custom_components/ --cov-append --cov-report=term-missing -v tests/ []
-
-commands_post =
-	# Show the `pylint` report to the standard output, to ease fixing the issues reported
-	cat pylint.txt


### PR DESCRIPTION
* `tox`, Github Actions: added testing with Python 3.13
* Updated version of test mocks (`pytest-homeassistant-custom-component` package) and its required dependencies
* `voluptious` package is now typed and its missing stubs no longer ignored for `mypy`
* `config_flow.py`: Fixed typing for `voluptious` schema declaration