### PR TITLE
feat: `OptionsFlowHandler` updated to follow recent HomeAssistant changes

### DIFF
--- a/custom_components/gs_alarm/config_flow.py
+++ b/custom_components/gs_alarm/config_flow.py
@@ -116,7 +116,7 @@ class G90ConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         Instantiates options flow handler.
         """
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
     def is_matching(self, other_flow: Self) -> bool:
         """
@@ -136,12 +136,6 @@ class OptionsFlowHandler(OptionsFlow):
     """
     Handle options (configure) flows.
     """
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """
-        Initialize options flow.
-        """
-        self.config_entry = config_entry
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,9 @@
 flake8==7.0.0
 pylint==3.0.3
-coverage==7.6.1
-pytest-homeassistant-custom-component==0.13.183
+coverage==7.6.8
+pytest-homeassistant-custom-component==0.13.190
 pytest==8.3.3
-pytest-cov==5.0.0
+pytest-cov==6.0.0
 pytest-unordered==0.6.1
 mypy[reports]==1.11.1
 pyg90alarm==1.16.0


### PR DESCRIPTION
* Constructor of `OptionsFlowHandler` derived class should no longer explicitly receive `config_entry` when instantiated - the base class takes care of that, see https://developers.home-assistant.io/blog/2024/11/12/options-flow for details
* Development dependencies have been updated, mostly for most recent version of `pytest-homeassistant-custom-component` (pulls in most recent HASS version)