### PR TITLE
fix: Update `pyg90alarm` to most recent version

### DIFF
--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -16,7 +16,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "pyg90alarm==1.16.1"
+    "pyg90alarm==1.17.0"
   ],
   "version": "1.22.1"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ pytest==8.3.3
 pytest-cov==6.0.0
 pytest-unordered==0.6.1
 mypy[reports]==1.11.1
-pyg90alarm==1.16.1
+pyg90alarm==1.17.0


### PR DESCRIPTION
Should help with empty device GUID issue, adds SOS and remote buttons support

Ref. issue: #49 