### PR TITLE
feat: Add tamper and door open when arming attributes to sensors

### DIFF
--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -106,6 +106,10 @@ class G90BinarySensor(BinarySensorEntity):
             self._attr_device_class = hass_sensor_type
         g90_sensor.state_callback = self.state_callback
         g90_sensor.low_battery_callback = self.low_battery_callback
+        g90_sensor.tamper_callback = self.tamper_callback
+        g90_sensor.door_open_when_arming_callback = (
+            self.door_open_when_arming_callback
+        )
         self._attr_device_info = hass_data.device
         self._hass_data = hass_data
 
@@ -141,6 +145,28 @@ class G90BinarySensor(BinarySensorEntity):
         # `extra_state_attributes()` method
         self.schedule_update_ha_state()
 
+    def tamper_callback(self) -> None:
+        """
+        Invoked by `pyg90alarm` when its sensor reports tampered condition.
+        """
+        _LOGGER.debug(
+            '%s: Received tamper callback', self.unique_id
+        )
+        # Signal HASS to update the sensor's attributes, which will trigger the
+        # `extra_state_attributes()` method
+        self.schedule_update_ha_state()
+
+    def door_open_when_arming_callback(self) -> None:
+        """
+        Invoked by `pyg90alarm` when its sensor reports door open when arming.
+        """
+        _LOGGER.debug(
+            '%s: Received door open when arming callback', self.unique_id
+        )
+        # Signal HASS to update the sensor's attributes, which will trigger the
+        # `extra_state_attributes()` method
+        self.schedule_update_ha_state()
+
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """
@@ -152,6 +178,11 @@ class G90BinarySensor(BinarySensorEntity):
             extra_attrs['low_battery'] = (
                 self._g90_sensor.is_low_battery
             )
+
+        extra_attrs['tampered'] = self._g90_sensor.is_tampered
+        extra_attrs['door_open_when_arming'] = (
+            self._g90_sensor.is_door_open_when_arming
+        )
 
         _LOGGER.debug(
             '%s: Providing extra attributes %s', self.unique_id,

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -16,7 +16,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "pyg90alarm==1.17.1"
+    "pyg90alarm==1.18.0"
   ],
   "version": "1.22.3"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ pytest==8.3.3
 pytest-cov==6.0.0
 pytest-unordered==0.6.1
 mypy[reports]==1.11.1
-pyg90alarm==1.17.1
+pyg90alarm==1.18.0


### PR DESCRIPTION
* Each panel sensors will now have `tampered` and `door_open_when_arming` attributes - which will be set to `true` when the sensor reports tampered or door open when arming conditions, respectively. Both of these attributes will be reset upon then panel is disarmed or armed back.

  Please note the `door_open_when_arming` attribute is only applicable to sensors have corresponding setting enabled in the mobile application named `Detect door&windows`