### PR TITLE
feat: update dependencies and GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,9 +33,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.12'
-            toxenv: py
-          - os: ubuntu-latest
             python: '3.13'
             toxenv: py
     runs-on: ${{ matrix.os }}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,8 @@
 flake8==7.0.0
 pylint==3.0.3
-coverage==7.6.8
-pytest-homeassistant-custom-component==0.13.190
-pytest==8.3.3
+coverage==7.6.12
+pytest-homeassistant-custom-component==0.13.235
+pytest==8.3.5
 pytest-cov==6.0.0
 pytest-unordered==0.6.1
 mypy[reports]==1.11.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Python 3.10 is no longer supported by HASS, see
 # https://github.com/home-assistant/core/pull/98640
-envlist = py{312,313}
+envlist = py{313}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and


### PR DESCRIPTION
- Updated GitHub Actions workflow and Tox to use Python 3.13 only (HASS testing package no longer supports Python 3.12)
- Updated dependencies to latest versions