### PR TITLE
feat: Sensor and alert configuration settings as switches

### DIFF
--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -68,10 +68,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
     for sensor in (
         hass.data[DOMAIN][entry.entry_id].panel_sensors
     ):
-        if sensor.enabled:
-            g90sensors.append(
-                G90BinarySensor(sensor, hass.data[DOMAIN][entry.entry_id])
-            )
+        g90sensors.append(
+            G90BinarySensor(sensor, hass.data[DOMAIN][entry.entry_id])
+        )
     g90sensors.append(
         G90WifiStatusSensor(hass.data[DOMAIN][entry.entry_id])
     )
@@ -98,7 +97,7 @@ class G90BinarySensor(BinarySensorEntity):
         self._attr_extra_state_attributes = {
             'panel_sensor_number': g90_sensor.index,
             'protocol': g90_sensor.protocol.name,
-            'flags': g90_sensor.user_flag.name,
+            'flags': g90_sensor.user_flags.name,
             'wireless': g90_sensor.is_wireless,
         }
         hass_sensor_type = HASS_SENSOR_TYPES_MAPPING.get(g90_sensor.type, None)
@@ -192,11 +191,15 @@ class G90BinarySensor(BinarySensorEntity):
         return extra_attrs
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """
         Indicates if sensor is active.
         """
-        val: bool = self._g90_sensor.occupancy
+        val = (
+            None if not self._g90_sensor.enabled
+            else self._g90_sensor.occupancy
+        )
+
         _LOGGER.debug('%s: Providing state %s', self.unique_id, val)
         return val
 

--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -196,6 +196,7 @@ class G90BinarySensor(BinarySensorEntity):
         Indicates if sensor is active.
         """
         val = (
+            # None translates to unknown state in HASS for disabled sensor
             None if not self._g90_sensor.enabled
             else self._g90_sensor.occupancy
         )

--- a/custom_components/gs_alarm/const.py
+++ b/custom_components/gs_alarm/const.py
@@ -5,7 +5,6 @@ DOMAIN = "gs_alarm"
 # Configuration options
 CONF_SMS_ALERT_WHEN_ARMED = "sms_alert_when_armed"
 CONF_SIMULATE_ALERTS_FROM_HISTORY = "simulate_alerts_from_history"
-CONF_DISABLED_SENSORS = "disabled_sensors"
 CONF_IP_ADDR = "ip_addr"
 CONF_CLOUD_LOCAL_PORT = "cloud_local_port"
 CONF_CLOUD_UPSTREAM_HOST = "cloud_upstream_host"

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -16,7 +16,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "pyg90alarm==2.0.1"
+    "pyg90alarm==2.1.1"
   ],
   "version": "2.0.0"
 }

--- a/custom_components/gs_alarm/select.py
+++ b/custom_components/gs_alarm/select.py
@@ -1,0 +1,91 @@
+"""
+Select entities for `gs_alarm` integration.
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING, List
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    EntityCategory,
+)
+from homeassistant.components.select import SelectEntity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from pyg90alarm import (
+    G90Sensor, G90Error, G90TimeoutError, G90SensorAlertModes,
+)
+
+from .const import DOMAIN
+if TYPE_CHECKING:
+    from . import GsAlarmData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up a config entry."""
+    g90sensors_mode: List[SelectEntity] = []
+    for sensor in (
+        hass.data[DOMAIN][entry.entry_id].panel_sensors
+    ):
+        g90sensors_mode.append(
+            G90SensorAlertMode(sensor, hass.data[DOMAIN][entry.entry_id])
+        )
+
+    async_add_entities(g90sensors_mode)
+
+
+class G90SensorAlertMode(SelectEntity):
+    # Not all base class methods are meaningfull in the context of the
+    # integration, silence the `pylint` for those
+    # pylint: disable=abstract-method
+    # pylint: disable=too-many-instance-attributes
+    """
+    Select entity for alert mode of the sensor.
+    """
+    states_map = {
+        G90SensorAlertModes.ALERT_ALWAYS:
+            "Alert always",
+        G90SensorAlertModes.ALERT_WHEN_AWAY:
+            "Alert when away",
+        G90SensorAlertModes.ALERT_WHEN_AWAY_AND_HOME:
+            "Alert when away and home",
+    }
+    reverse_states_map = dict(
+        zip(states_map.values(), states_map.keys())
+    )
+
+    def __init__(self, sensor: G90Sensor, hass_data: GsAlarmData) -> None:
+        self._sensor = sensor
+        self._attr_unique_id = (
+            f"{hass_data.guid}_sensor_{sensor.index}_alert_mode"
+        )
+        self._attr_name = f"{sensor.name}: Alert mode"
+        self._attr_device_info = hass_data.device
+        self._hass_data = hass_data
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_options = list(self.states_map.values())
+
+    @property
+    def current_option(self) -> str | None:
+        return self.states_map.get(self._sensor.alert_mode, None)
+
+    async def async_select_option(self, option: str) -> None:
+        """
+        Set the mode of the sensor.
+        """
+        try:
+            # Select component should ensure the correct option is
+            # selected
+            await self._sensor.set_alert_mode(self.reverse_states_map[option])
+        except (G90Error, G90TimeoutError) as exc:
+            _LOGGER.error(
+                "Error setting alert mode for sensor '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )

--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -1,18 +1,21 @@
 """
-Switches for `gs_alarm` integration.
+Switch entities for `gs_alarm` integration.
 """
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, List
 import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-
+from homeassistant.const import (
+    EntityCategory,
+)
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from pyg90alarm import (
-    G90Device, G90Error, G90TimeoutError
+    G90Device, G90Sensor, G90Error, G90TimeoutError,
+    G90SensorUserFlags, G90AlertConfigFlags,
 )
 
 from .const import DOMAIN
@@ -27,13 +30,83 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up a config entry."""
-    g90switches = []
+    g90switches: List[SwitchEntity] = []
     for device in (
         hass.data[DOMAIN][entry.entry_id].panel_devices
     ):
         g90switches.append(
             G90Switch(device, hass.data[DOMAIN][entry.entry_id])
         )
+
+    for sensor in (
+        hass.data[DOMAIN][entry.entry_id].panel_sensors
+    ):
+        if sensor.supports_updates:
+            g90switches.extend([
+                G90SensorFlag(
+                    sensor, hass.data[DOMAIN][entry.entry_id],
+                    G90SensorUserFlags.ENABLED, "Enabled"
+                ),
+                G90SensorFlag(
+                    sensor, hass.data[DOMAIN][entry.entry_id],
+                    G90SensorUserFlags.ARM_DELAY, "Arm delay"
+                ),
+                G90SensorFlag(
+                    sensor, hass.data[DOMAIN][entry.entry_id],
+                    G90SensorUserFlags.DETECT_DOOR, "Detect door"
+                ),
+                G90SensorFlag(
+                    sensor, hass.data[DOMAIN][entry.entry_id],
+                    G90SensorUserFlags.DOOR_CHIME, "Door chime"
+                ),
+                G90SensorFlag(
+                    sensor, hass.data[DOMAIN][entry.entry_id],
+                    G90SensorUserFlags.INDEPENDENT_ZONE, "Independent zone"
+                ),
+            ])
+
+    g90switches.extend([
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.AC_POWER_FAILURE, "AC Power failure"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.AC_POWER_RECOVER, "AC Power recover"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.ARM_DISARM, "Arm disarm"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.HOST_LOW_VOLTAGE, "Host low voltage"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.SENSOR_LOW_VOLTAGE, "Sensor low voltage"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.WIFI_AVAILABLE, "WiFi available"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.WIFI_UNAVAILABLE, "WiFi unavailable"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.DOOR_OPEN, "Door open"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.DOOR_CLOSE, "Door close"
+        ),
+        G90AlertConfigFlag(
+            hass.data[DOMAIN][entry.entry_id],
+            G90AlertConfigFlags.SMS_PUSH, "SMS push"
+        ),
+    ])
 
     async_add_entities(g90switches)
 
@@ -43,7 +116,7 @@ class G90Switch(SwitchEntity):
     # integration, silence the `pylint` for those
     # pylint: disable=abstract-method
     """
-    Switch specific to alarm panel.
+    Switch specific to the alarm panel's device (relay).
     """
     def __init__(self, device: G90Device, hass_data: GsAlarmData) -> None:
         self._device = device
@@ -96,3 +169,144 @@ class G90Switch(SwitchEntity):
         else:
             # See comment above
             self._state = False
+
+
+class G90SensorFlag(SwitchEntity):
+    # Not all base class methods are meaningfull in the context of the
+    # integration, silence the `pylint` for those
+    # pylint: disable=abstract-method
+    """
+    Switch entity for configuration option of the sensor.
+    """
+    def __init__(
+        self, sensor: G90Sensor, hass_data: GsAlarmData,
+        flag: G90SensorUserFlags, flag_name: str
+    ) -> None:
+        self._sensor = sensor
+        self._flag = flag
+        self._attr_unique_id = (
+            f"{hass_data.guid}_sensor_{sensor.index}_{flag_name.lower()}"
+        )
+        self._attr_name = f"{sensor.name}: {flag_name}"
+        self._attr_device_info = hass_data.device
+        self._hass_data = hass_data
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def is_on(self) -> bool:
+        """
+        Indicates if the switch is active (on).
+        """
+        value = self._sensor.get_flag(self._flag)
+        _LOGGER.debug(
+            "%s: Sensor flag '%s' is %s",
+            self.unique_id, self._flag.name, value
+        )
+        return value
+
+    async def async_turn_on(self, **_kwargs: Any) -> None:
+        """
+        Turn on the switch.
+        """
+        try:
+            _LOGGER.debug(
+                "%s: Switching on the sensor flag '%s'",
+                self.unique_id, self._flag.name
+            )
+            await self._sensor.set_flag(self._flag, True)
+        except (G90Error, G90TimeoutError) as exc:
+            _LOGGER.error(
+                "Error switching on the sensor flag '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """
+        Turn off the switch.
+        """
+        try:
+            _LOGGER.debug(
+                "%s: Switching off the sensor flag '%s'",
+                self.unique_id, self._flag.name
+            )
+            await self._sensor.set_flag(self._flag, False)
+        except (G90Error, G90TimeoutError) as exc:
+            _LOGGER.error(
+                "Error switching off the sensor flag '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )
+
+
+class G90AlertConfigFlag(SwitchEntity):
+    # Not all base class methods are meaningfull in the context of the
+    # integration, silence the `pylint` for those
+    # pylint: disable=abstract-method
+    """
+    Switch entity for alert configuration option of the panel.
+    """
+    def __init__(
+        self, hass_data: GsAlarmData, flag: G90AlertConfigFlags, flag_name: str
+    ) -> None:
+        self._flag = flag
+        self._attr_unique_id = f"{hass_data.guid}_{flag_name.lower()}"
+        self._attr_name = f"Alert: {flag_name}"
+        self._attr_device_info = hass_data.device
+        self._hass_data = hass_data
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def async_added_to_hass(self) -> None:
+        # Signal HASS to update the state as soon as component is added,
+        # which will trigger the `async_update` method - that will provide
+        # the up-to-date state w/o waiting for next interval
+        await self.async_update_ha_state(force_refresh=True)
+
+    async def async_update(self) -> None:
+        """
+        Indicates if the switch is active (on).
+        """
+        value = await self._hass_data.client.alert_config.get_flag(self._flag)
+        _LOGGER.debug(
+            "%s: Alert config flag '%s' is %s",
+            self.unique_id, self._flag.name, value
+        )
+        self._attr_is_on = value
+
+    async def async_turn_on(self, **_kwargs: Any) -> None:
+        """
+        Turn on the switch.
+        """
+        try:
+            _LOGGER.debug(
+                "%s: Switching on the alert config flag '%s'",
+                self.unique_id, self._flag.name
+            )
+            await self._hass_data.client.alert_config.set_flag(
+                self._flag, True
+            )
+        except (G90Error, G90TimeoutError) as exc:
+            _LOGGER.error(
+                "Error switching on the alert config flag '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """
+        Turn off the switch.
+        """
+        try:
+            _LOGGER.debug(
+                "%s: Switching off the alert config flag '%s'",
+                self.unique_id, self._flag.name
+            )
+            await self._hass_data.client.alert_config.set_flag(
+                self._flag, False
+            )
+        except (G90Error, G90TimeoutError) as exc:
+            _LOGGER.error(
+                "Error switching off the alert config flag '%s': %s",
+                self.unique_id,
+                repr(exc)
+            )

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ pytest==8.3.5
 pytest-cov==6.0.0
 pytest-unordered==0.6.1
 mypy[reports]==1.11.1
-pyg90alarm==2.0.1
+pyg90alarm==2.1.1

--- a/tests/test_option_flow.py
+++ b/tests/test_option_flow.py
@@ -1,7 +1,7 @@
 """
 Tests for option (configure) flow for the custom component.
 """
-from unittest.mock import PropertyMock, call
+from unittest.mock import call
 from typing import Dict, Any
 
 import pytest
@@ -50,20 +50,12 @@ async def test_config_flow_options(
         flow_id=result['flow_id'],
         user_input={
             'sms_alert_when_armed': True,
-            'disabled_sensors': ['0'],
             'simulate_alerts_from_history': True,
         },
     )
     # Verify it results in (re)creating corresponding entry in HomeAssistant
     assert result['type'] == FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
-    # Verify the sensor has to its `set_enabled()` method invoked with proper
-    # arguments
-    (
-        mock_g90alarm.return_value
-        .get_sensors.return_value[0]
-        .set_enabled
-    ).assert_called_once_with(False)
 
     # Verify the value of the `sms_alert_when_armed` property of `G90Alarm()`
     # instance
@@ -144,7 +136,6 @@ async def test_config_flow_options_notifications_protocol(
         flow_id=result['flow_id'],
         user_input={
             'sms_alert_when_armed': False,
-            'disabled_sensors': [],
             'simulate_alerts_from_history': False,
             'notifications_protocol': protocol,
         },
@@ -190,49 +181,3 @@ async def test_config_flow_options_notifications_protocol(
         getattr(call, expected_call)(**expected_kwargs),
         call.listen_notifications(),
     ])
-
-
-async def test_config_flow_options_unsupported_disable(
-    hass: HomeAssistant, mock_g90alarm: AlarmMockT
-) -> None:
-    """
-    Tests options (configure) flow for the component where sensor attempted to
-    disable and it isn't supported.
-    """
-    # Instantiate the component into HomeAssistant, required for its options
-    # flow handler to be registered
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={},
-    )
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-
-    # Initial step
-    result = await hass.config_entries.options.async_init(
-        config_entry.entry_id,
-        context={"source": "user"},
-    )
-    # Verify it results in form
-    assert result['step_id'] == 'init'
-    assert result['type'] == FlowResultType.FORM
-
-    # Simulate the sensor doesn't support enabling/disabling
-    (
-        type(mock_g90alarm.return_value.get_sensors.return_value[0])
-        .supports_enable_disable
-    ) = PropertyMock(return_value=False)
-
-    # Submission step configuring the single mocked sensor to be disabled
-    result = await hass.config_entries.options.async_configure(
-        flow_id=result['flow_id'],
-        user_input={'disabled_sensors': ['0']},
-    )
-    # Verify it results in (re)creating corresponding entry in HomeAssistant
-    assert result['type'] == FlowResultType.CREATE_ENTRY
-    # Verify disabling the sensor has not been called
-    (
-        mock_g90alarm.return_value
-        .get_sensors.return_value[0]
-        .set_enabled
-    ).assert_not_called()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,120 @@
+
+"""
+Test for selects in the custom component.
+"""
+from __future__ import annotations
+import pytest
+
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+)
+
+from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+)
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+
+from pyg90alarm import G90SensorAlertModes, G90Error
+
+from custom_components.gs_alarm.const import DOMAIN
+from .conftest import AlarmMockT
+
+
+@pytest.mark.parametrize(
+    "entity_id,service_call,option,expected_value",
+    [
+        pytest.param(
+            "select.dummy_sensor_1_alert_mode", SERVICE_SELECT_OPTION,
+            "Alert always",
+            G90SensorAlertModes.ALERT_ALWAYS,
+            id="Alert always"
+        ),
+        pytest.param(
+            "select.dummy_sensor_1_alert_mode", SERVICE_SELECT_OPTION,
+            "Alert when away",
+            G90SensorAlertModes.ALERT_WHEN_AWAY,
+            id="Alert when away"
+        ),
+        pytest.param(
+            "select.dummy_sensor_1_alert_mode", SERVICE_SELECT_OPTION,
+            "Alert when away and home",
+            G90SensorAlertModes.ALERT_WHEN_AWAY_AND_HOME,
+            id="Alert when away and home"
+        ),
+    ],
+)
+# pylint: disable=too-many-arguments
+async def test_sensor_alert_modes(
+    entity_id: str, service_call: str,
+    option: str,
+    expected_value: G90SensorAlertModes,
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
+) -> None:
+    """
+    Tests sensor alert modes are set correctly thru corresponding select.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test_sensor_alert_modes"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Change the sensor alert mode thru state of corresponding select
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        service_call,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: option},
+        blocking=True,
+    )
+
+    # Verify the sensor alert mode was set correctly
+    sensor = mock_g90alarm.return_value.get_sensors.return_value[0]
+    sensor.set_alert_mode.assert_called_once_with(expected_value)
+
+
+async def test_sensor_alert_modes_exception(
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
+) -> None:
+    """
+    Tests sensor alert modes are set correctly thru corresponding select.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test_sensor_alert_modes_exception"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    sensor = mock_g90alarm.return_value.get_sensors.return_value[0]
+    # Simulate an exception when setting the sensor alert mode
+    sensor.set_alert_mode.side_effect = G90Error('dummy exception')
+
+    entity_id = 'select.dummy_sensor_1_alert_mode'
+    # Attempt to change the alert mode of the sensor, which shouldn't raise
+    # an exception
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_OPTION: 'Alert always'
+        },
+        blocking=True,
+    )
+
+    # Verify the switch for the sensor mode is still in previous state
+    dummy_sensor_1_alert_mode = hass.states.get(entity_id)
+    assert dummy_sensor_1_alert_mode is not None
+    assert dummy_sensor_1_alert_mode.state == 'Alert when away'

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,327 @@
+"""
+Tests for switches from the custom component.
+"""
+from __future__ import annotations
+import pytest
+
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+)
+
+from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_ON,
+    SERVICE_TURN_OFF,
+)
+from homeassistant.components.switch.const import (
+    DOMAIN as SWITCH_DOMAIN
+)
+
+from pyg90alarm import G90SensorUserFlags, G90AlertConfigFlags, G90Error
+
+from custom_components.gs_alarm.const import DOMAIN
+from .conftest import AlarmMockT
+
+
+@pytest.mark.parametrize(
+    "entity_id,service_call,expected_flag,expected_value",
+    [
+        pytest.param(
+            "switch.dummy_sensor_1_enabled", SERVICE_TURN_ON,
+            G90SensorUserFlags.ENABLED, True,
+            id="Enable sensor"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_enabled", SERVICE_TURN_OFF,
+            G90SensorUserFlags.ENABLED, False,
+            id="Disable sensor"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_arm_delay", SERVICE_TURN_ON,
+            G90SensorUserFlags.ARM_DELAY, True,
+            id="Enable arm delay"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_arm_delay", SERVICE_TURN_OFF,
+            G90SensorUserFlags.ARM_DELAY, False,
+            id="Disable arm delay"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_detect_door", SERVICE_TURN_ON,
+            G90SensorUserFlags.DETECT_DOOR, True,
+            id="Enable detect door"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_detect_door", SERVICE_TURN_OFF,
+            G90SensorUserFlags.DETECT_DOOR, False,
+            id="Disable detect door"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_door_chime", SERVICE_TURN_ON,
+            G90SensorUserFlags.DOOR_CHIME, True,
+            id="Enable door chime"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_door_chime", SERVICE_TURN_OFF,
+            G90SensorUserFlags.DOOR_CHIME, False,
+            id="Disable door chime"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_independent_zone", SERVICE_TURN_ON,
+            G90SensorUserFlags.INDEPENDENT_ZONE, True,
+            id="Enable independent zone"
+        ),
+        pytest.param(
+            "switch.dummy_sensor_1_independent_zone", SERVICE_TURN_OFF,
+            G90SensorUserFlags.INDEPENDENT_ZONE, False,
+            id="Disable independent zone"
+        ),
+    ],
+)
+# pylint: disable=too-many-arguments
+async def test_sensor_flags(
+    entity_id: str, service_call: str,
+    expected_flag: G90SensorUserFlags, expected_value: bool,
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
+) -> None:
+    """
+    Tests sensor flags are set correctly thru corresponding switches.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test_sensor_flags"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Change the sensor flag thru state of corresponding switch
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service_call,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    # Verify the sensor flag was set correctly
+    sensor = mock_g90alarm.return_value.get_sensors.return_value[0]
+    sensor.set_flag.assert_called_once_with(expected_flag, expected_value)
+
+
+async def test_sensor_flags_exception(
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
+) -> None:
+    """
+    Tests exceptions are properly handled changing sensor user flags.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test_sensor_flags_exception"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Simulate an exception when setting the sensor flag
+    sensor = mock_g90alarm.return_value.get_sensors.return_value[0]
+    sensor.set_flag.side_effect = G90Error('dummy exception')
+
+    entity_id = 'switch.dummy_sensor_1_enabled'
+    # Attempt to turn off the switch for the sensor enabled flag
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    # Verify the switch for the sensor enabled flag is still on
+    dummy_sensor_1_enabled = hass.states.get(entity_id)
+    assert dummy_sensor_1_enabled is not None
+    assert dummy_sensor_1_enabled.state == 'on'
+
+    # Attempt to turn on the switch - no exception should be raised
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "entity_id,service_call,expected_flag,expected_value",
+    [
+        pytest.param(
+            "switch.alert_ac_power_failure", SERVICE_TURN_ON,
+            G90AlertConfigFlags.AC_POWER_FAILURE, True,
+            id="AC power failure enabled"
+        ),
+        pytest.param(
+            "switch.alert_ac_power_failure", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.AC_POWER_FAILURE, False,
+            id="AC power failure disabled"
+        ),
+        pytest.param(
+            "switch.alert_wifi_available", SERVICE_TURN_ON,
+            G90AlertConfigFlags.WIFI_AVAILABLE, True,
+            id="WiFi available enabled"
+        ),
+        pytest.param(
+            "switch.alert_wifi_available", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.WIFI_AVAILABLE, False,
+            id="WiFi available disabled"
+        ),
+        pytest.param(
+            "switch.alert_wifi_unavailable", SERVICE_TURN_ON,
+            G90AlertConfigFlags.WIFI_UNAVAILABLE, True,
+            id="WiFi unavailable enabled"
+        ),
+        pytest.param(
+            "switch.alert_wifi_unavailable", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.WIFI_UNAVAILABLE, False,
+            id="WiFi unavailable disabled"
+        ),
+        pytest.param(
+            "switch.alert_door_open", SERVICE_TURN_ON,
+            G90AlertConfigFlags.DOOR_OPEN, True,
+            id="Door open enabled"
+        ),
+        pytest.param(
+            "switch.alert_door_open", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.DOOR_OPEN, False,
+            id="Door open disabled"
+        ),
+        pytest.param(
+            "switch.alert_door_close", SERVICE_TURN_ON,
+            G90AlertConfigFlags.DOOR_CLOSE, True,
+            id="Door close enabled"
+        ),
+        pytest.param(
+            "switch.alert_door_close", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.DOOR_CLOSE, False,
+            id="Door close disabled"
+        ),
+        pytest.param(
+            "switch.alert_sms_push", SERVICE_TURN_ON,
+            G90AlertConfigFlags.SMS_PUSH, True,
+            id="SMS push enabled"
+        ),
+        pytest.param(
+            "switch.alert_sms_push", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.SMS_PUSH, False,
+            id="SMS push disabled"
+        ),
+        pytest.param(
+            "switch.alert_arm_disarm", SERVICE_TURN_ON,
+            G90AlertConfigFlags.ARM_DISARM, True,
+            id="Arm disarm enabled"
+        ),
+        pytest.param(
+            "switch.alert_arm_disarm", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.ARM_DISARM, False,
+            id="Arm disarm disabled"
+        ),
+        pytest.param(
+            "switch.alert_host_low_voltage", SERVICE_TURN_ON,
+            G90AlertConfigFlags.HOST_LOW_VOLTAGE, True,
+            id="Host low voltage enabled"
+        ),
+        pytest.param(
+            "switch.alert_host_low_voltage", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.HOST_LOW_VOLTAGE, False,
+            id="Host low voltage disabled"
+        ),
+        pytest.param(
+            "switch.alert_sensor_low_voltage", SERVICE_TURN_ON,
+            G90AlertConfigFlags.SENSOR_LOW_VOLTAGE, True,
+            id="Sensor low voltage enabled"
+        ),
+        pytest.param(
+            "switch.alert_sensor_low_voltage", SERVICE_TURN_OFF,
+            G90AlertConfigFlags.SENSOR_LOW_VOLTAGE, False,
+            id="Sensor low voltage disabled"
+        ),
+    ],
+)
+# pylint: disable=too-many-arguments
+async def test_alert_config_flags(
+    entity_id: str, service_call: str,
+    expected_flag: G90AlertConfigFlags, expected_value: bool,
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
+) -> None:
+    """
+    Tests alert config flags are set correctly thru corresponding switches.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test_sensor_flags"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Change the alert config flag thru state of corresponding switch
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service_call,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    # Verify the alert config flag was set correctly
+    alert_config = mock_g90alarm.return_value.alert_config
+    alert_config.set_flag.assert_called_once_with(
+        expected_flag, expected_value
+    )
+
+
+async def test_alert_config_flags_exception(
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
+) -> None:
+    """
+    Tests exceptions are properly handled changing alert config flags.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test_sensor_flags_exception"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Simulate an exception when setting the alert flags
+    mock_g90alarm.return_value.alert_config.set_flag.side_effect = G90Error(
+        'dummy exception'
+    )
+
+    entity_id = 'switch.alert_host_low_voltage'
+    # Attempt to turn off the switch for the alert config flag
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    # Verify the switch for the alert config flag is still on
+    alert_config_flag_switch = hass.states.get(entity_id)
+    assert alert_config_flag_switch is not None
+    assert alert_config_flag_switch.state == 'on'
+
+    # Attempt to turn on the switch - no exception should be raised
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )


### PR DESCRIPTION
Sensors and alert configuration settings are now available as switches. While it might not be the best UI experience if you have many sensors, but the change makes the configuration of better visibility and allows programmatically control it.

Each sensor has separate switches for each cofiguration option (e.g. enabled, has delay arming etc.), as well as its alert mode (alert only when armed away, alert always etc.).
Additionally, alert configuration for the panel has been added same way - you can now control what alerts are enabled (on door open or close, on sensor low battery etc.).

Disabling/enabling sensors through integration options (`Configure` button in Home Assistant UI) is no longer available.