### PR TITLE
fix: Remove debug logging statement

### DIFF
--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -294,7 +294,6 @@ class G90SensorFlag(
         self._attr_icon = icon
         self._attr_has_entity_name = True
         self._attr_translation_key = f'sensor_flag_{str(flag.name).lower()}'
-        _LOGGER.warning("Translation key: %s", self._attr_translation_key)
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
* `G90SensorFlag` no longer logs translation key at warning level, which is a leftover from debugging.