### PR TITLE
chore(deps): Unpin some development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       - "dependencies"
       - "automated"
     open-pull-requests-limit: 5
+    ignore:
+      # These are pinned by `pytest-homeassistant-custom-component` package and
+      # can't be updated independently.
+      - dependency-name: "pytest"
+      - dependency-name: "coverage"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,10 @@
 flake8==7.3.0
 pylint==4.0.4
-coverage==7.10.6
 pytest-homeassistant-custom-component==0.13.301
-pytest==9.0.0
 pytest-cov==7.0.0
 pytest-unordered==0.7.0
 mypy[reports]==1.19.1
 pyg90alarm==2.3.1
+# These are pinned by `pytest-homeassistant-custom-component` package
+pytest
+coverage


### PR DESCRIPTION
* Unpin `pytest` and `coverage` in `requirements_dev.txt` as they are already pinned by `pytest-homeassistant-custom-component` package. Subsequently these are also ignored in Dependabot, since those can't be updated independently.