### PR TITLE
fix: Update `pyg90alarm` to allow invalid APN auth received from some panels

### DIFF
--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -19,7 +19,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "pyg90alarm==2.5.2"
+    "pyg90alarm==2.5.3"
   ],
   "version": "3.4.2"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ pytest-homeassistant-custom-component==0.13.308
 pytest-cov==7.0.0
 pytest-unordered==0.7.0
 mypy[reports]==1.19.1
-pyg90alarm==2.5.2
+pyg90alarm==2.5.3
 # These are pinned by `pytest-homeassistant-custom-component` package
 pytest
 coverage


### PR DESCRIPTION
## User-visible changes
- Updating the `pyg90alarm` dependency allows to safely process values for APN authentication some panels might send that are considered invalid by previous versions of the library. Once updated, reading such value with result in `None`. When saving an unmodified value, the original invalid value is preserved and sent back to the panel.