### PR TITLE
fix: Stop alert simulation task during component unload

### DIFF
--- a/custom_components/gs_alarm/__init__.py
+++ b/custom_components/gs_alarm/__init__.py
@@ -203,6 +203,9 @@ async def async_unload_entry(
         'Platforms unloaded %ssuccessfully', '' if unload_ok else 'un'
     )
     if unload_ok:
+        # Ensure task simulating alerts from history is stopped
+        await entry.runtime_data.client.stop_simulating_alerts_from_history()
+        # Stop listening for notifications
         await entry.runtime_data.client.close_notifications()
         _LOGGER.debug('Custom component unloaded')
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -432,12 +432,13 @@ async def test_config_flags_exception(
         blocking=True,
     )
 
-    # Simulate an exception when setting the config flag.
     # `attrgetter` is used to handle nested attribute names (dot notation) -
     # `getattr` only works for single level attributes
-    attrgetter(expected_call)(
+    meth = attrgetter(expected_call)(
         mock_g90alarm.return_value
-    ).side_effect = simulated_exception
+    )
+    # Simulate an exception when setting the config flag.
+    meth.side_effect = simulated_exception
 
     # Attempt to set the switch for the config flag to the desired state
     await hass.services.async_call(
@@ -446,6 +447,10 @@ async def test_config_flags_exception(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
+
+    # Remove simulated exception so that component unloading can stop the
+    # simulation task
+    meth.side_effect = None
 
     # Verify the switch for the config flag is in the expected state (i.e. did
     # not change due to the exception)


### PR DESCRIPTION
* Recent Python 3.14 versions will show error if closing a process with async task still running - in particular that applies to the task handling alert simulation from history (if enabled). Hence, `async_unload_entry` now explicitly stops such task by calling `G90Alarm.stop_simulating_alerts_from_history()` method
* Tests for exceptions handling in the HASS switch entity controlling if alert simulation enable are now properly simular the exception only once, to allow simulation task to be properly stopped during component unload