### PR TITLE
fix: Align entity IDs with Home Assistant platform domains

### DIFF
--- a/custom_components/gs_alarm/alarm_control_panel.py
+++ b/custom_components/gs_alarm/alarm_control_panel.py
@@ -11,6 +11,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
 )
+from homeassistant.components.alarm_control_panel.const import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.alarm_control_panel.const import (
     AlarmControlPanelEntityFeature, AlarmControlPanelState,
@@ -55,6 +58,7 @@ class G90AlarmPanel(
     # pylint: disable=too-many-ancestors
     UNIQUE_ID_FMT = "{guid}"
     ENTITY_ID_FMT = "{guid}"
+    ENTITY_DOMAIN = ALARM_CONTROL_PANEL_DOMAIN
 
     def __init__(self, coordinator: GsAlarmCoordinator) -> None:
         super().__init__(coordinator)

--- a/custom_components/gs_alarm/binary_sensor.py
+++ b/custom_components/gs_alarm/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass,
+    DOMAIN as BINARY_SENSOR_DOMAIN,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -105,6 +106,16 @@ async def async_setup_entry(
     ])
 
 
+class G90PanelBinarySensorEntity(BinarySensorEntity, GSAlarmEntityBase):
+    """
+    Binary sensor linked to the alarm panel device using coordinator data.
+
+    Uses the binary_sensor platform domain for generated entity IDs.
+    """
+    # pylint: disable=too-few-public-methods,too-many-ancestors
+    ENTITY_DOMAIN = BINARY_SENSOR_DOMAIN
+
+
 class G90BinarySensor(
     BinarySensorEntity, CoordinatorEntity[GsAlarmCoordinator],
     GSAlarmGenerateIDsSensorMixin
@@ -119,6 +130,7 @@ class G90BinarySensor(
 
     UNIQUE_ID_FMT = "{guid}_sensor_{sensor.index}"
     ENTITY_ID_FMT = "{guid}_{sensor.name}"
+    ENTITY_DOMAIN = BINARY_SENSOR_DOMAIN
 
     def __init__(
         self, g90_sensor: G90Sensor, coordinator: GsAlarmCoordinator
@@ -278,6 +290,8 @@ class G90SensorAttributeBase(
     """
     # pylint: disable=too-many-instance-attributes,too-many-arguments
     # pylint: disable=too-many-positional-arguments
+    ENTITY_DOMAIN = BINARY_SENSOR_DOMAIN
+
     def __init__(
         self, g90_sensor: G90Sensor, coordinator: GsAlarmCoordinator,
         sensor_attr: str,
@@ -393,9 +407,7 @@ class G90SensorAttributeDoorOpenWhenArming(G90SensorAttributeBase):
         self._attr_icon = 'mdi:door-open'
 
 
-class G90WifiStatusSensor(
-    BinarySensorEntity, GSAlarmEntityBase,
-):
+class G90WifiStatusSensor(G90PanelBinarySensorEntity):
     """
     WiFi status sensor.
 
@@ -426,9 +438,7 @@ class G90WifiStatusSensor(
         self.async_write_ha_state()
 
 
-class G90GsmStatusSensor(
-    BinarySensorEntity, GSAlarmEntityBase,
-):
+class G90GsmStatusSensor(G90PanelBinarySensorEntity):
     """
     GSM status sensor.
 
@@ -460,9 +470,7 @@ class G90GsmStatusSensor(
         self.async_write_ha_state()
 
 
-class G90Gprs3GActiveSensor(
-    GSAlarmEntityBase, BinarySensorEntity
-):
+class G90Gprs3GActiveSensor(G90PanelBinarySensorEntity):
     """
     GPRS/3G status sensor.
 
@@ -491,7 +499,7 @@ class G90Gprs3GActiveSensor(
         self.async_write_ha_state()
 
 
-class G90NotificationsProtocol(GSAlarmEntityBase, BinarySensorEntity):
+class G90NotificationsProtocol(G90PanelBinarySensorEntity):
     """
     Binary sensor for notifications protocol connectivity.
     """

--- a/custom_components/gs_alarm/button.py
+++ b/custom_components/gs_alarm/button.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import device_registry as dr
 from homeassistant.const import EntityCategory, STATE_UNKNOWN
 from homeassistant.components.button import ButtonEntity
+from homeassistant.components.button.const import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.persistent_notification import (
     DOMAIN as NOTIFICATION_DOMAIN, ATTR_MESSAGE, ATTR_TITLE
 )
@@ -129,9 +130,25 @@ class G90EntityDeleteButtonBase(
             )
 
 
-class G90SwitchDelete(
-    G90EntityDeleteButtonBase, GSAlarmGenerateIDsDeviceMixin
+class G90SwitchDeleteButtonEntity(
+    G90EntityDeleteButtonBase,
+    GSAlarmGenerateIDsDeviceMixin,
 ):
+    # pylint: disable=too-many-ancestors
+    """Delete relay button base; ENTITY_DOMAIN for generated entity IDs."""
+    ENTITY_DOMAIN = BUTTON_DOMAIN
+
+
+class G90SensorDeleteButtonEntity(
+    G90EntityDeleteButtonBase,
+    GSAlarmGenerateIDsSensorMixin,
+):
+    # pylint: disable=too-many-ancestors
+    """Delete sensor button base; ENTITY_DOMAIN for generated entity IDs."""
+    ENTITY_DOMAIN = BUTTON_DOMAIN
+
+
+class G90SwitchDelete(G90SwitchDeleteButtonEntity):
     """
     Button to delete the relay from the alarm panel.
 
@@ -166,10 +183,7 @@ class G90SwitchDelete(
         return 'device'
 
 
-class G90SensorDelete(
-    G90EntityDeleteButtonBase,
-    GSAlarmGenerateIDsSensorMixin
-):
+class G90SensorDelete(G90SensorDeleteButtonEntity):
     """
     Button to delete the sensor from the alarm panel.
 
@@ -215,6 +229,8 @@ class G90NewEntityRegisterButtonBase(
     """
     # pylint:disable=abstract-method
     # pylint: disable=too-many-ancestors
+    ENTITY_DOMAIN = BUTTON_DOMAIN
+
     def __init__(self, coordinator: GsAlarmCoordinator) -> None:
         super().__init__(coordinator)
 

--- a/custom_components/gs_alarm/entity_base.py
+++ b/custom_components/gs_alarm/entity_base.py
@@ -11,10 +11,14 @@ from homeassistant.const import STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.components.select import SelectEntity
+from homeassistant.components.select.const import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number.const import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.components.text.const import DOMAIN as TEXT_DOMAIN
 from homeassistant.const import EntityCategory
 
 from pyg90alarm import (
@@ -66,6 +70,8 @@ class GsAlarmSwitchRestoreEntityBase(
     :param coordinator: The coordinator to use.
     """
     # pylint: disable=too-many-ancestors
+    ENTITY_DOMAIN = SWITCH_DOMAIN
+
     def __init__(
         self, coordinator: GsAlarmCoordinator,
     ) -> None:
@@ -294,6 +300,8 @@ class G90ConfigSelectFieldBase(G90ConfigFieldBase, SelectEntity):
     # pylint: disable=abstract-method,too-many-instance-attributes
     # pylint: disable=too-many-ancestors
     # pylint: disable=too-many-arguments,too-many-positional-arguments
+    ENTITY_DOMAIN = SELECT_DOMAIN
+
     def __init__(
         self, coordinator: GsAlarmCoordinator,
         field_name: str, states_map: dict[Any, str], icon: str,
@@ -354,6 +362,8 @@ class G90ConfigNumberFieldBase(G90ConfigFieldBase, NumberEntity):
     """
     # pylint:disable=too-many-ancestors,too-many-instance-attributes
     # pylint: disable=too-many-arguments,too-many-positional-arguments
+    ENTITY_DOMAIN = NUMBER_DOMAIN
+
     def __init__(
         self, coordinator: GsAlarmCoordinator, field_name: str,
         icon: str, unit: str, id_field_name: Optional[str] = None
@@ -417,6 +427,8 @@ class G90ConfigTextFieldBase(G90ConfigFieldBase, TextEntity):
     # pylint: disable=abstract-method,too-many-instance-attributes
     # pylint: disable=too-many-ancestors
     # pylint: disable=too-many-arguments,too-many-positional-arguments
+    ENTITY_DOMAIN = TEXT_DOMAIN
+
     def __init__(
         self, coordinator: GsAlarmCoordinator,
         field_name: str, icon: str, is_password: bool,
@@ -509,6 +521,8 @@ class G90ConfigSwitchFieldBase(G90ConfigFieldBase, SwitchEntity):
     # pylint: disable=abstract-method,too-many-instance-attributes
     # pylint: disable=too-many-ancestors
     # pylint: disable=too-many-arguments,too-many-positional-arguments
+    ENTITY_DOMAIN = SWITCH_DOMAIN
+
     def __init__(
         self, coordinator: GsAlarmCoordinator,
         field_name: str, icon: str,

--- a/custom_components/gs_alarm/mixin.py
+++ b/custom_components/gs_alarm/mixin.py
@@ -30,6 +30,7 @@ class GSAlarmGenerateIDsMixinBase(ABC):
     """
     UNIQUE_ID_FMT: Optional[str] = None
     ENTITY_ID_FMT: Optional[str] = None
+    ENTITY_DOMAIN: Optional[str] = None
 
     @classmethod
     @abstractmethod
@@ -97,11 +98,13 @@ class GSAlarmGenerateIDsMixinBase(ABC):
         if not cls.ENTITY_ID_FMT:
             raise NotImplementedError("ENTITY_ID_FMT is not defined")
 
-        # Formally, the entity ID should have first component being the
-        # platform name (e.g. `swoitch.`, `sensor.` etc), but practically any
-        # content there works, HASS seems properly parsing it out and replacing
-        # it with platform name as needed.
-        return f'{DOMAIN}.{slugify(
+        if not cls.ENTITY_DOMAIN:
+            raise NotImplementedError("ENTITY_DOMAIN is not defined")
+
+        # Entity ID must use the Home Assistant entity platform domain
+        # (e.g. switch, binary_sensor) as the first segment, not the
+        # integration domain.
+        return f'{cls.ENTITY_DOMAIN}.{slugify(
             cls.ENTITY_ID_FMT.format(
                 guid=coordinator.data.host_info.host_guid, **placeholders
             )

--- a/custom_components/gs_alarm/select.py
+++ b/custom_components/gs_alarm/select.py
@@ -10,7 +10,9 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.components.select import SelectEntity
+from homeassistant.components.select import (
+    SelectEntity, DOMAIN as SELECT_DOMAIN,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.core import Event
 
@@ -31,6 +33,16 @@ if TYPE_CHECKING:
     from . import GsAlarmConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class G90SelectSensorEntityBase(
+    SelectEntity,
+    CoordinatorEntity[GsAlarmCoordinator],
+    GSAlarmGenerateIDsSensorMixin,
+):
+    # pylint: disable=too-many-ancestors
+    """Select entity tied to a panel sensor; platform domain for entity IDs."""
+    ENTITY_DOMAIN = SELECT_DOMAIN
 
 
 async def async_setup_entry(
@@ -131,16 +143,14 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class G90SensorAlertMode(
-    SelectEntity, CoordinatorEntity[GsAlarmCoordinator],
-    GSAlarmGenerateIDsSensorMixin
-):
+class G90SensorAlertMode(G90SelectSensorEntityBase):
     """
     Select entity for alert mode of the sensor.
 
     :param sensor: The sensor to create the entity for.
     :param coordinator: The coordinator to use.
     """
+    # pylint: disable=too-many-ancestors
     # pylint: disable=abstract-method,too-many-instance-attributes
     states_map = {
         G90SensorAlertModes.ALERT_ALWAYS:
@@ -216,6 +226,8 @@ class G90NewEntitySelectBase(
     """
     # pylint: disable=abstract-method,too-many-instance-attributes
     # pylint: disable=too-many-ancestors
+    ENTITY_DOMAIN = SELECT_DOMAIN
+
     def __init__(
         self, coordinator: GsAlarmCoordinator
     ) -> None:

--- a/custom_components/gs_alarm/sensor.py
+++ b/custom_components/gs_alarm/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
     SensorDeviceClass,
 )
+from homeassistant.components.sensor.const import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     EntityCategory, PERCENTAGE, UnitOfElectricPotential,
 )
@@ -48,6 +49,8 @@ class G90BaseSensor(
     """
     # pylint:disable=too-few-public-methods
     # pylint: disable=too-many-ancestors
+    ENTITY_DOMAIN = SENSOR_DOMAIN
+
     def __init__(self, coordinator: GsAlarmCoordinator) -> None:
         super().__init__(coordinator)
 

--- a/custom_components/gs_alarm/switch.py
+++ b/custom_components/gs_alarm/switch.py
@@ -10,6 +10,7 @@ import logging
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.const import EntityCategory
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -173,10 +174,49 @@ async def async_setup_entry(
     async_add_entities(config_switches)
 
 
-class G90Switch(
-    SwitchEntity, CoordinatorEntity[GsAlarmCoordinator],
-    GSAlarmGenerateIDsDeviceMixin
+class GsAlarmSwitchDeviceEntity(
+    SwitchEntity,
+    CoordinatorEntity[GsAlarmCoordinator],
+    GSAlarmGenerateIDsDeviceMixin,
 ):
+    # pylint: disable=too-many-ancestors
+    """Relay switch; ENTITY_DOMAIN for entity ID generation."""
+    ENTITY_DOMAIN = SWITCH_DOMAIN
+
+
+class GsAlarmSwitchSensorConfigEntity(
+    SwitchEntity,
+    CoordinatorEntity[GsAlarmCoordinator],
+    GSAlarmGenerateIDsSensorMixin,
+):
+    # pylint: disable=too-many-ancestors
+    """Sensor config switch; ENTITY_DOMAIN for entity IDs."""
+    ENTITY_DOMAIN = SWITCH_DOMAIN
+
+
+class GsAlarmSwitchPanelConfigEntity(
+    SwitchEntity,
+    CoordinatorEntity[GsAlarmCoordinator],
+    GSAlarmGenerateIDsCommonMixin,
+):
+    # pylint: disable=too-many-ancestors
+    """Panel-level switch; ENTITY_DOMAIN for entity IDs."""
+    ENTITY_DOMAIN = SWITCH_DOMAIN
+
+
+class GsAlarmSwitchStandaloneEntity(
+    SwitchEntity,
+    GSAlarmGenerateIDsCommonMixin,
+):
+    # pylint: disable=too-many-ancestors
+    """
+    Switch without coordinator participation (e.g. reboot); supplies platform
+    domain for entity ID generation.
+    """
+    ENTITY_DOMAIN = SWITCH_DOMAIN
+
+
+class G90Switch(GsAlarmSwitchDeviceEntity):
     """
     Switch for the alarm panel's relay.
 
@@ -279,10 +319,7 @@ class G90Switch(
             self.async_write_ha_state()
 
 
-class G90SensorFlag(
-    SwitchEntity, CoordinatorEntity[GsAlarmCoordinator],
-    GSAlarmGenerateIDsSensorMixin
-):
+class G90SensorFlag(GsAlarmSwitchSensorConfigEntity):
     """
     Switch entity for configuration option of the sensor.
 
@@ -380,10 +417,7 @@ class G90SensorFlag(
         await self.coordinator.async_request_refresh()
 
 
-class G90AlertConfigFlag(
-    SwitchEntity, CoordinatorEntity[GsAlarmCoordinator],
-    GSAlarmGenerateIDsCommonMixin
-):
+class G90AlertConfigFlag(GsAlarmSwitchPanelConfigEntity):
     """
     Switch entity for alert configuration option of the panel.
 
@@ -480,7 +514,7 @@ class G90AlertConfigFlag(
         await self.coordinator.async_request_refresh()
 
 
-class G90RebootSwitch(SwitchEntity, GSAlarmGenerateIDsCommonMixin):
+class G90RebootSwitch(GsAlarmSwitchStandaloneEntity):
     """
     Stateless switch to reboot the alarm panel.
 

--- a/custom_components/gs_alarm/text.py
+++ b/custom_components/gs_alarm/text.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import HomeAssistant
 from homeassistant.const import EntityCategory
 from homeassistant.components.text import TextEntity
+from homeassistant.components.text.const import DOMAIN as TEXT_DOMAIN
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.core import Event
 
@@ -135,6 +136,8 @@ class G90NewEntityTextBase(
     """
     # pylint: disable=abstract-method,too-many-instance-attributes
     # pylint: disable=too-many-ancestors
+    ENTITY_DOMAIN = TEXT_DOMAIN
+
     def __init__(
         self, coordinator: GsAlarmCoordinator
     ) -> None:


### PR DESCRIPTION
The change adds `ENTITY_DOMAIN` class attribute to `GSAlarmGenerateIDsMixinBase` class, which is then used by `generate_entity_id_with_placeholders` method as the first segment in the generated entity IDs - previously the segment been hard-coded to the integration domain. That is [now deprecated in Home Assistant](https://developers.home-assistant.io/blog/2026/04/07/entity-id-mismatched-domain-deprecated/).

The `ENTITY_DOMAIN` attribute is then utilized in a set of shared base classes those have been introduced for specific entity types to reduce code duplication, although there are certain cases where the attribute is applied to concrete classes directly if no duplication introduced.