### PR TITLE
feat: Support renaming sensors and relays

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ supports them (some panels do not expose SIA/CID configuration).
 | Volume: Ring | Volume level for incoming call (Mute/Low/High), only available on panels with cellular support |
 | Volume: Speech | Volume level for speech announcements (Mute/Low/High) |
 
+## Renaming Sensors and Relays
+
+The integration allows you to rename sensors and relays directly from Home Assistant. Each sensor and relay device has a corresponding "Panel name" text entity that can be used to update the name on the alarm panel.
+
+**Important:** When you rename a sensor or relay, the integration automatically reloads to ensure the new name is properly reflected throughout Home Assistant entities causing a brief unavailability of all those.
+
+To rename a sensor or relay:
+1. Navigate to the device in Home Assistant (Settings -> Devices & Services -> Golden Security Alarm -> \<serial number\>)
+2. Find the corresponding "Panel name" text entity
+3. Enter the new name and navigate away from the entity to save the changes
+4. The integration will update the panel and reload automatically
+
 ## Notifications
 
 Notifications from the alarm panel are essential for the integration -

--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -19,7 +19,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "pyg90alarm==2.12.1"
+    "pyg90alarm==2.13.1"
   ],
   "version": "3.12.1"
 }

--- a/custom_components/gs_alarm/text.py
+++ b/custom_components/gs_alarm/text.py
@@ -4,7 +4,9 @@
 Text entities for `gs_alarm` integration.
 """
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
+import logging
+from abc import ABC, abstractmethod
 
 from homeassistant.core import HomeAssistant
 from homeassistant.const import EntityCategory
@@ -12,6 +14,10 @@ from homeassistant.components.text import TextEntity
 from homeassistant.components.text.const import DOMAIN as TEXT_DOMAIN
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.core import Event
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers import device_registry as dr
+
+from pyg90alarm import G90Device, G90Sensor, G90Error, G90TimeoutError
 
 from .const import DOMAIN
 from .entity_base import (
@@ -19,8 +25,13 @@ from .entity_base import (
     G90SiaConfigTextField, G90CidConfigTextField,
 )
 from .coordinator import GsAlarmCoordinator
+from .mixin import GSAlarmGenerateIDsSensorMixin, GSAlarmGenerateIDsDeviceMixin
+from .binary_sensor import G90BinarySensor
+from .switch import G90Switch
 if TYPE_CHECKING:
     from . import GsAlarmConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -28,7 +39,25 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up a config entry."""
+    def device_list_change_callback(device: G90Device, added: bool) -> None:
+        # Add rename text entity for new device if it is the primary element
+        if added and device.subindex == 0:
+            async_add_entities([G90DeviceName(device, coordinator)])
+
+    def sensor_list_change_callback(sensor: G90Sensor, added: bool) -> None:
+        # Similarly, but for sensors
+        if added and sensor.supports_updates:
+            async_add_entities([G90SensorName(sensor, coordinator)])
+
     coordinator = entry.runtime_data
+    # Register callback to add rename text entities for new sensors/devices
+    entry.runtime_data.client.device_list_change_callback.add(
+        device_list_change_callback
+    )
+    entry.runtime_data.client.sensor_list_change_callback.add(
+        sensor_list_change_callback
+    )
+
     entities: list[Any] = [
         # Text entities for new sensor and relay names
         G90NewSensorName(coordinator),
@@ -209,3 +238,178 @@ class G90NewDeviceName(G90NewEntityTextBase):
         self.coordinator.hass.bus.async_listen(
             f"{DOMAIN}_new_device_registration", self.handle_registration_event
         )
+
+
+class G90RenameTextEntityBase(
+    TextEntity,
+    CoordinatorEntity[GsAlarmCoordinator],
+    ABC
+):
+    """
+    Base class for sensor/device rename text entities.
+    """
+    # pylint: disable=too-many-ancestors,too-many-instance-attributes
+    ENTITY_DOMAIN: Optional[str] = TEXT_DOMAIN
+
+    def __init__(self, coordinator: GsAlarmCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_icon = 'mdi:pencil'
+        self._attr_has_entity_name = True
+
+    @property
+    @abstractmethod
+    def entity_kind(self) -> str:
+        """
+        Kind of panel entity being renamed.
+        """
+
+    @property
+    @abstractmethod
+    def panel_name(self) -> str:
+        """
+        Current name as known to alarm panel.
+        """
+
+    @abstractmethod
+    async def set_panel_name(self, value: str) -> None:
+        """
+        Rename entity on alarm panel.
+        """
+
+    async def async_set_value(self, value: str) -> None:
+        """
+        Set value and apply rename on panel immediately.
+        """
+        # Ignore empty or whitespace-only names
+        if not value or value.isspace():
+            _LOGGER.debug(
+                "Empty %s name supplied for '%s', rename is ignored",
+                self.entity_kind, self.unique_id
+            )
+            return
+
+        # Rename the entity on the panel
+        try:
+            await self.set_panel_name(value)
+        except (G90Error, G90TimeoutError) as exc:
+            _LOGGER.error(
+                "Error renaming %s '%s' to '%s': %s",
+                self.entity_kind,
+                self.unique_id,
+                value,
+                repr(exc)
+            )
+            return
+        _LOGGER.debug(
+            "Renamed %s '%s' to '%s'",
+            self.entity_kind, self.unique_id, value
+        )
+
+        self._attr_native_value = value
+
+        if self.registry_entry and self.registry_entry.device_id:
+            # Update device name immediately in device registry.
+            # This should be updated during config entry reload below,
+            # but we do it here for immediate visibility.
+            dr.async_get(self.hass).async_update_device(
+                self.registry_entry.device_id,
+                name=value
+            )
+
+        # Request data update from panel to reflect the new name
+        await self.coordinator.async_request_refresh()
+
+        # Ideally, this should only reload entities for the renamed
+        # sensor/device, but the entity registry caches original_name
+        # when entities are first registered. The only reliable way to
+        # update this cache is to reload the integration, which removes
+        # and re-adds all entities with fresh naming metadata.
+        # This causes brief unavailability of all integration
+        # entities, but ensures the name change is reflected.
+        if self.coordinator.config_entry:
+            self.coordinator.hass.config_entries.async_schedule_reload(
+                self.coordinator.config_entry.entry_id
+            )
+
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> str:
+        return self.panel_name
+
+
+class G90SensorName(
+    G90RenameTextEntityBase,
+    GSAlarmGenerateIDsSensorMixin
+):
+    """
+    Text entity to rename panel sensor.
+    """
+    # pylint: disable=too-many-ancestors
+    UNIQUE_ID_FMT = "{guid}_sensor_{sensor.index}_panel_name"
+    ENTITY_ID_FMT = "{guid}_{sensor.name}_panel_name"
+
+    def __init__(
+        self, sensor: G90Sensor, coordinator: GsAlarmCoordinator
+    ) -> None:
+        super().__init__(coordinator)
+        self._sensor = sensor
+        self._attr_unique_id = self.generate_unique_id(coordinator, sensor)
+        self.entity_id = self.generate_entity_id(coordinator, sensor)
+        # The text entity is bound to the HASS device representing the sensor
+        self._attr_device_info = G90BinarySensor.generate_device_info(
+            coordinator, sensor
+        )
+
+        self._attr_translation_key = 'sensor_panel_name'
+        self._attr_native_value = sensor.name
+
+    @property
+    def entity_kind(self) -> str:
+        return 'sensor'
+
+    @property
+    def panel_name(self) -> str:
+        return self._sensor.name
+
+    async def set_panel_name(self, value: str) -> None:
+        await self._sensor.set_name(value)
+
+
+class G90DeviceName(
+    G90RenameTextEntityBase,
+    GSAlarmGenerateIDsDeviceMixin
+):
+    """
+    Text entity to rename panel relay.
+    """
+    # pylint: disable=too-many-ancestors
+    UNIQUE_ID_FMT = "{guid}_switch_{device.index}_panel_name"
+    ENTITY_ID_FMT = "{guid}_{device.name}_panel_name"
+
+    def __init__(
+        self, device: G90Device, coordinator: GsAlarmCoordinator
+    ) -> None:
+        super().__init__(coordinator)
+        self._device = device
+        self._attr_unique_id = self.generate_unique_id(coordinator, device)
+        self.entity_id = self.generate_entity_id(coordinator, device)
+        # The text entity is bound to the HASS device representing the relay
+        self._attr_device_info = G90Switch.generate_device_info(
+            coordinator, device
+        )
+
+        self._attr_translation_key = 'device_panel_name'
+        self._attr_native_value = device.name
+
+    @property
+    def entity_kind(self) -> str:
+        return 'device'
+
+    @property
+    def panel_name(self) -> str:
+        return self._device.name
+
+    async def set_panel_name(self, value: str) -> None:
+        await self._device.set_name(value)

--- a/custom_components/gs_alarm/translations/be.json
+++ b/custom_components/gs_alarm/translations/be.json
@@ -376,6 +376,12 @@
             "new_device_name": {
                 "name": "Новае рэле: імя"
             },
+            "sensor_panel_name": {
+                "name": "Імя ў панэлі"
+            },
+            "device_panel_name": {
+                "name": "Імя ў панэлі"
+            },
             "sia_host": {
                 "name": "SIA: Хост"
             },

--- a/custom_components/gs_alarm/translations/da.json
+++ b/custom_components/gs_alarm/translations/da.json
@@ -376,6 +376,12 @@
             "apn_password": {
                 "name": "Mobilnet: APN-adgangskode"
             },
+            "sensor_panel_name": {
+                "name": "Panelnavn"
+            },
+            "device_panel_name": {
+                "name": "Panelnavn"
+            },
             "sia_host": {
                 "name": "SIA: Vært"
             },

--- a/custom_components/gs_alarm/translations/de.json
+++ b/custom_components/gs_alarm/translations/de.json
@@ -376,6 +376,12 @@
             "apn_password": {
                 "name": "Mobilfunk: APN-Passwort"
             },
+            "sensor_panel_name": {
+                "name": "Panel-Name"
+            },
+            "device_panel_name": {
+                "name": "Panel-Name"
+            },
             "sia_host": {
                 "name": "SIA: Host"
             },

--- a/custom_components/gs_alarm/translations/en.json
+++ b/custom_components/gs_alarm/translations/en.json
@@ -334,6 +334,12 @@
             "new_device_name": {
                 "name": "New relay: name"
             },
+            "sensor_panel_name": {
+                "name": "Panel name"
+            },
+            "device_panel_name": {
+                "name": "Panel name"
+            },
             "panel_password": {
                 "name": "Panel: Password"
             },

--- a/custom_components/gs_alarm/translations/es.json
+++ b/custom_components/gs_alarm/translations/es.json
@@ -376,6 +376,12 @@
             "apn_password": {
                 "name": "Celular: contraseña APN"
             },
+            "sensor_panel_name": {
+                "name": "Nombre del panel"
+            },
+            "device_panel_name": {
+                "name": "Nombre del panel"
+            },
             "sia_host": {
                 "name": "SIA: Host"
             },

--- a/custom_components/gs_alarm/translations/fr.json
+++ b/custom_components/gs_alarm/translations/fr.json
@@ -376,6 +376,12 @@
             "apn_password": {
                 "name": "Cellulaire: mot de passe APN"
             },
+            "sensor_panel_name": {
+                "name": "Nom du panneau"
+            },
+            "device_panel_name": {
+                "name": "Nom du panneau"
+            },
             "sia_host": {
                 "name": "SIA: Hôte"
             },

--- a/custom_components/gs_alarm/translations/it.json
+++ b/custom_components/gs_alarm/translations/it.json
@@ -376,6 +376,12 @@
             "apn_password": {
                 "name": "Cellulare: password APN"
             },
+            "sensor_panel_name": {
+                "name": "Nome del pannello"
+            },
+            "device_panel_name": {
+                "name": "Nome del pannello"
+            },
             "sia_host": {
                 "name": "SIA: Host"
             },

--- a/custom_components/gs_alarm/translations/nl.json
+++ b/custom_components/gs_alarm/translations/nl.json
@@ -376,6 +376,12 @@
             "apn_password": {
                 "name": "Mobiel: APN-wachtwoord"
             },
+            "sensor_panel_name": {
+                "name": "Paneelnaam"
+            },
+            "device_panel_name": {
+                "name": "Paneelnaam"
+            },
             "sia_host": {
                 "name": "SIA: Host"
             },

--- a/custom_components/gs_alarm/translations/no-bok.json
+++ b/custom_components/gs_alarm/translations/no-bok.json
@@ -376,6 +376,12 @@
             "new_device_name": {
                 "name": "Nytt relaisnavn"
             },
+            "sensor_panel_name": {
+                "name": "Panelnavn"
+            },
+            "device_panel_name": {
+                "name": "Panelnavn"
+            },
             "sia_host": {
                 "name": "SIA: Vert"
             },

--- a/custom_components/gs_alarm/translations/no-nyn.json
+++ b/custom_components/gs_alarm/translations/no-nyn.json
@@ -376,6 +376,12 @@
             "new_device_name": {
                 "name": "Nytt relaisnavn"
             },
+            "sensor_panel_name": {
+                "name": "Panelnamn"
+            },
+            "device_panel_name": {
+                "name": "Panelnamn"
+            },
             "sia_host": {
                 "name": "SIA: Vert"
             },

--- a/custom_components/gs_alarm/translations/pl.json
+++ b/custom_components/gs_alarm/translations/pl.json
@@ -376,6 +376,12 @@
             "new_device_name": {
                 "name": "Nowa nazwa przekaźnika"
             },
+            "sensor_panel_name": {
+                "name": "Nazwa w panelu"
+            },
+            "device_panel_name": {
+                "name": "Nazwa w panelu"
+            },
             "sia_host": {
                 "name": "SIA: Host"
             },

--- a/custom_components/gs_alarm/translations/pt.json
+++ b/custom_components/gs_alarm/translations/pt.json
@@ -376,6 +376,12 @@
             "new_device_name": {
                 "name": "Novo relé: nome"
             },
+            "sensor_panel_name": {
+                "name": "Nome do painel"
+            },
+            "device_panel_name": {
+                "name": "Nome do painel"
+            },
             "sia_host": {
                 "name": "SIA: Host"
             },

--- a/custom_components/gs_alarm/translations/ru.json
+++ b/custom_components/gs_alarm/translations/ru.json
@@ -376,6 +376,12 @@
             "new_device_name": {
                 "name": "Новое имя реле"
             },
+            "sensor_panel_name": {
+                "name": "Имя в панели"
+            },
+            "device_panel_name": {
+                "name": "Имя в панели"
+            },
             "sia_host": {
                 "name": "SIA: Хост"
             },

--- a/custom_components/gs_alarm/translations/sv.json
+++ b/custom_components/gs_alarm/translations/sv.json
@@ -376,6 +376,12 @@
             "new_device_name": {
                 "name": "Nytt relä-namn"
             },
+            "sensor_panel_name": {
+                "name": "Panelnamn"
+            },
+            "device_panel_name": {
+                "name": "Panelnamn"
+            },
             "sia_host": {
                 "name": "SIA: Värd"
             },

--- a/custom_components/gs_alarm/translations/uk.json
+++ b/custom_components/gs_alarm/translations/uk.json
@@ -376,6 +376,12 @@
             "new_device_name": {
                 "name": "Нове реле: ім'я"
             },
+            "sensor_panel_name": {
+                "name": "Ім'я в панелі"
+            },
+            "device_panel_name": {
+                "name": "Ім'я в панелі"
+            },
             "sia_host": {
                 "name": "SIA: Хост"
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
         'kwargs', {}
     ).get('result', True)
 
+    # Mocked sensor and device names, to support simulating renaming those
     sensor_names = {
         0: 'Dummy sensor'
     }
@@ -152,6 +153,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
             async def set_sensor_name(
                 name: str, sensor: G90Sensor = mock_sensor
             ) -> None:
+                """ Simulates setting the sensor name on the panel. """
                 sensor_names[sensor.index] = name
                 sensor.protocol_data.parent_name = name
 
@@ -258,6 +260,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
             async def set_device_name(
                 name: str, device: G90Device = mock_device
             ) -> None:
+                """ Simulates setting the device name on the panel. """
                 device_names[device.index] = name
                 device.protocol_data.parent_name = name
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,15 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
         'kwargs', {}
     ).get('result', True)
 
+    sensor_names = {
+        0: 'Dummy sensor'
+    }
+    device_names = {
+        0: 'Dummy switch 1',
+        1: 'Dummy switch 2 multi-node',
+        2: 'Dummy switch 3 multi-node',
+    }
+
     # Create host info return value
     host_info = G90HostInfo(
         host_guid='Dummy GUID',
@@ -120,7 +129,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
                 # Has to point to `G90Alarm()` instance
                 parent=mock.return_value,
                 subindex=0, proto_idx=0,
-                parent_name='Dummy sensor',
+                parent_name=sensor_names[0],
                 index=0,
                 room_id=0,
                 type_id=1,
@@ -140,12 +149,20 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
             )
         ]
         for mock_sensor in mock_sensors:
+            async def set_sensor_name(
+                name: str, sensor: G90Sensor = mock_sensor
+            ) -> None:
+                sensor_names[sensor.index] = name
+                sensor.protocol_data.parent_name = name
+
             mock_sensor.set_alert_mode = (  # type: ignore[method-assign]
                 AsyncMock()
             )
             mock_sensor.set_flag = AsyncMock()  # type: ignore[method-assign]
+            mock_sensor.set_name = AsyncMock(  # type: ignore[method-assign]
+                side_effect=set_sensor_name
+            )
             mock_sensor.delete = AsyncMock()  # type: ignore[method-assign]
-
             yield mock_sensor
 
     async def device_list_fetch(
@@ -157,7 +174,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
         mock_devices = [
             G90Device(
                 parent=mock.return_value, subindex=0, proto_idx=1,
-                parent_name='Dummy switch 1',
+                parent_name=device_names[0],
                 index=0,
                 room_id=0,
                 type_id=128,
@@ -173,7 +190,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
             ),
             G90Device(
                 parent=mock.return_value, subindex=0, proto_idx=2,
-                parent_name='Dummy switch 2 multi-node',
+                parent_name=device_names[1],
                 index=1,
                 room_id=0,
                 type_id=128,
@@ -189,7 +206,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
             ),
             G90Device(
                 parent=mock.return_value, subindex=1, proto_idx=2,
-                parent_name='Dummy switch 2 multi-node',
+                parent_name=device_names[1],
                 index=1,
                 room_id=0,
                 type_id=128,
@@ -205,7 +222,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
             ),
             G90Device(
                 parent=mock.return_value, subindex=0, proto_idx=3,
-                parent_name='Dummy switch 3 multi-node',
+                parent_name=device_names[2],
                 index=2,
                 room_id=0,
                 type_id=128,
@@ -221,7 +238,7 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
             ),
             G90Device(
                 parent=mock.return_value, subindex=1, proto_idx=3,
-                parent_name='Dummy switch 3 multi-node',
+                parent_name=device_names[2],
                 index=2,
                 room_id=0,
                 type_id=128,
@@ -238,8 +255,17 @@ def mock_g90alarm(request: pytest.FixtureRequest) -> Iterator[AlarmMockT]:
         ]
 
         for mock_device in mock_devices:
+            async def set_device_name(
+                name: str, device: G90Device = mock_device
+            ) -> None:
+                device_names[device.index] = name
+                device.protocol_data.parent_name = name
+
             mock_device.turn_on = AsyncMock()  # type: ignore[method-assign]
             mock_device.turn_off = AsyncMock()  # type: ignore[method-assign]
+            mock_device.set_name = AsyncMock(  # type: ignore[method-assign]
+                side_effect=set_device_name
+            )
             mock_device.delete = AsyncMock()  # type: ignore[method-assign]
 
             yield mock_device

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -444,6 +444,10 @@ async def test_setup_unload_and_reload_entry_afresh(
                 'unique_id': 'dummy_guid_sensor_0_delete',
                 'entity_id': 'button.dummy_guid_dummy_sensor_delete',
                 'name': 'Delete',
+            }, {
+                'unique_id': 'dummy_guid_sensor_0_panel_name',
+                'entity_id': 'text.dummy_guid_dummy_sensor_panel_name',
+                'name': 'Panel name',
             }, ])
         },
         {
@@ -457,6 +461,10 @@ async def test_setup_unload_and_reload_entry_afresh(
                 'unique_id': 'dummy_guid_switch_0_delete',
                 'entity_id': 'button.dummy_guid_dummy_switch_1_delete',
                 'name': 'Delete',
+            }, {
+                'unique_id': 'dummy_guid_switch_0_panel_name',
+                'entity_id': 'text.dummy_guid_dummy_switch_1_panel_name',
+                'name': 'Panel name',
             }, ])
         },
         {
@@ -475,6 +483,11 @@ async def test_setup_unload_and_reload_entry_afresh(
                 'entity_id':
                     'button.dummy_guid_dummy_switch_2_multi_node_1_delete',
                 'name': 'Delete',
+            }, {
+                'unique_id': 'dummy_guid_switch_1_panel_name',
+                'entity_id':
+                    'text.dummy_guid_dummy_switch_2_multi_node_1_panel_name',
+                'name': 'Panel name',
             }, ])
         },
         {
@@ -496,6 +509,12 @@ async def test_setup_unload_and_reload_entry_afresh(
                     'entity_id':
                         'button.dummy_guid_dummy_switch_3_multi_node_1_delete',
                     'name': 'Delete',
+                }, {
+                    'unique_id': 'dummy_guid_switch_2_panel_name',
+                    'entity_id':
+                        'text'
+                        '.dummy_guid_dummy_switch_3_multi_node_1_panel_name',
+                    'name': 'Panel name',
                 },
             ])
         },

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -25,7 +25,11 @@ from homeassistant.components.text.const import (
 from pyg90alarm import G90Error
 
 from custom_components.gs_alarm.const import DOMAIN
-from .conftest import AlarmMockT, hass_get_entity_id_by_unique_id
+from .conftest import (
+    AlarmMockT,
+    hass_get_entity_id_by_unique_id,
+    entry_ids_for_integration_devices,
+)
 
 
 @pytest.mark.parametrize(
@@ -357,3 +361,111 @@ async def test_cid_config_text_entities(
     assert getattr(
         await mock_g90alarm.return_value.cid_config(), field
     ) == value
+
+
+@pytest.mark.parametrize(
+    "unique_id,old_name,new_name,all_entities_call,"
+    "expect_name_change,simulated_exception",
+    [
+        pytest.param(
+            "dummy_guid_sensor_0_panel_name",
+            "Dummy sensor", "Renamed sensor",
+            "get_sensors",
+            True, None,
+            id="Rename sensor"
+        ),
+        pytest.param(
+            "dummy_guid_switch_0_panel_name",
+            "Dummy switch 1", "Renamed relay",
+            "get_devices",
+            True, None,
+            id="Rename device"
+        ),
+        pytest.param(
+            "dummy_guid_sensor_0_panel_name",
+            "Dummy sensor", "  ",
+            "get_sensors",
+            False, None,
+            id="Empty sensor name"
+        ),
+        pytest.param(
+            "dummy_guid_switch_0_panel_name",
+            "Dummy switch 1", "  ",
+            "get_devices",
+            False, None,
+            id="Empty device name"
+        ),
+        pytest.param(
+            "dummy_guid_sensor_0_panel_name",
+            "Dummy sensor", "Dummy sensor",
+            "get_sensors",
+            False, G90Error('dummy exception'),
+            id="Exception when renaming sensor"
+        ),
+        pytest.param(
+            "dummy_guid_switch_0_panel_name",
+            "Dummy switch 1", "Dummy switch 1",
+            "get_devices",
+            False, G90Error('dummy exception'),
+            id="Exception when renaming device"
+        ),
+    ],
+)
+async def test_rename_text_entities(
+    unique_id: str, old_name: str, new_name: str,
+    all_entities_call: str, expect_name_change: bool,
+    simulated_exception: G90Error,
+    hass: HomeAssistant, mock_g90alarm: AlarmMockT
+) -> None:
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    """
+    Tests text entities for renaming sensors and devices.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={'ip_addr': 'dummy-ip'},
+        options={},
+        entry_id="test_rename_text_entities"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Find the alarm entity (sensor or device) to rename
+    alarm_entity = next(
+        iter(
+            x for x in await getattr(mock_g90alarm, all_entities_call)()
+            if x.name == old_name
+        )
+    )
+    # Simulate an exception when renaming the entity if requested
+    alarm_entity.set_name.side_effect = simulated_exception
+
+    # Attempt to rename the entity
+    entity_id = hass_get_entity_id_by_unique_id(
+        hass, 'text', unique_id
+    )
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: new_name},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Verify the entity name has been changed if requested
+    new_entity_name = new_name if expect_name_change else old_name
+    assert any(
+        x['device'] == new_entity_name
+        for x in entry_ids_for_integration_devices(
+            hass, config_entry.entry_id
+        )
+    )
+
+    if not expect_name_change and not simulated_exception:
+        # Verify the corresponding call has not been made
+        alarm_entity.set_name.assert_not_called()
+    else:
+        # Verify the corresponding call has been made (either successfully
+        # or with an exception)
+        alarm_entity.set_name.assert_called_once_with(new_name)


### PR DESCRIPTION
The change adds text entities allowing users to rename panel sensors and relays directly from Home Assistant. Each sensor/relay device receives a corresponding "Panel name" text entity that updates the alarm panel using the `set_name` method exposed by `pyg90alarm` library.

When a rename occurs, the integration performs a config entry reload to ensure entity naming metadata reflects the new name. This causes brief unavailability of all integration entities, which is necessary because Home Assistant caches entity metadata that cannot be updated incrementally.

The device registry is updated with the new name immediately for user feedback, using the `name` field (integration default) to maintain consistency with the panel as the source of truth.