### PR TITLE
fix: Update dependencies for reload issue

### DIFF
--- a/custom_components/gs_alarm/manifest.json
+++ b/custom_components/gs_alarm/manifest.json
@@ -19,7 +19,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "pyg90alarm==2.13.1"
+    "pyg90alarm==2.13.2"
   ],
   "version": "3.13.0"
 }

--- a/custom_components/gs_alarm/translations/en.json
+++ b/custom_components/gs_alarm/translations/en.json
@@ -136,10 +136,10 @@
                 "name": "Notifications protocol",
                 "state_attributes": {
                     "last_device_packet_timestamp": {
-                        "name": "last_device_packet_timestamp"
+                        "name": "Last device packet timestamp"
                     },
                     "last_upstream_packet_timestamp": {
-                        "name": "last_upstream_packet_timestamp"
+                        "name": "Last upstream packet timestamp"
                     }
                 }
             }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ pylint==4.0.5
 pytest-homeassistant-custom-component==0.13.329
 pytest-unordered==0.7.0
 mypy[reports]==2.0.0
-pyg90alarm==2.13.1
+pyg90alarm==2.13.2
 # These are pinned by `pytest-homeassistant-custom-component` package
 pytest
 pytest-cov


### PR DESCRIPTION
- `pyg90alarm` package updated to `2.13.2` to fix the reload issue, manifesting itself when a sensor is renamed, the integration reloads and the sensor state is no longer updated from panel's events.
- Cosmetic update to EN translations.