### PR TITLE
chore: Fix flakiness in CI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ Pytest configuration and fixtures
 from __future__ import annotations
 from typing import Iterator, TypeVar, Any, AsyncGenerator, Dict, List
 from unittest.mock import patch, AsyncMock, PropertyMock, DEFAULT
+import asyncio
 import pytest
 
 from homeassistant.core import HomeAssistant, State
@@ -587,3 +588,12 @@ def entry_ids_for_integration_devices(
             dr.async_get(hass), entry_id
         )
     ]
+
+
+async def allow_callbacks_to_complete(hass: HomeAssistant) -> None:
+    """
+    Allows callbacks to complete.
+    """
+    await hass.async_block_till_done()
+    # Allow callbacks to complete
+    await asyncio.sleep(0)

--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -18,7 +18,9 @@ from homeassistant.const import (
 from pyg90alarm import G90ArmDisarmTypes
 
 from custom_components.gs_alarm.const import DOMAIN
-from .conftest import AlarmMockT, hass_get_state_by_unique_id
+from .conftest import (
+    AlarmMockT, hass_get_state_by_unique_id, allow_callbacks_to_complete,
+)
 
 
 @pytest.mark.g90host_status(
@@ -38,7 +40,7 @@ async def test_alarm_panel_requests_refresh_on_service_calls(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Replace coordinator refresh method with a mock so we can assert calls
     coordinator = config_entry.runtime_data

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -3,7 +3,6 @@
 """
 Tests callbacks for the custom component.
 """
-import asyncio
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -16,7 +15,9 @@ from homeassistant.components.alarm_control_panel.const import (
 from pyg90alarm import G90ArmDisarmTypes
 
 from custom_components.gs_alarm.const import DOMAIN
-from .conftest import AlarmMockT, hass_get_state_by_unique_id
+from .conftest import (
+    AlarmMockT, hass_get_state_by_unique_id, allow_callbacks_to_complete,
+)
 
 
 @pytest.mark.g90host_status(
@@ -36,13 +37,13 @@ async def test_alarm_callback(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Simulate the alarm callback is triggered
     await mock_g90alarm.return_value.on_alarm(
         0, 'Dummy sensor', is_tampered=False
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify panel state and attributes reflect that
     panel_state = hass_get_state_by_unique_id(
@@ -59,7 +60,7 @@ async def test_alarm_callback(
     await mock_g90alarm.return_value.on_armdisarm(
         G90ArmDisarmTypes.ARM_AWAY
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify `changed_by` attribute has been reset
     panel_state = hass_get_state_by_unique_id(
@@ -88,13 +89,13 @@ async def test_arm_callback(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Simulate the arm callback is triggered
     await mock_g90alarm.return_value.on_armdisarm(
         G90ArmDisarmTypes.ARM_AWAY
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify panel state reflects that
     panel_state = hass_get_state_by_unique_id(
@@ -123,13 +124,13 @@ async def test_disarm_callback(
 
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Simulate the disarm callback is triggered
     await mock_g90alarm.return_value.on_armdisarm(
         G90ArmDisarmTypes.DISARM
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify panel state reflects that
     panel_state = hass_get_state_by_unique_id(
@@ -156,13 +157,12 @@ async def test_low_battery_callback(
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     # Allow Home Assistant to process the setup
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     await mock_g90alarm.return_value.on_low_battery(
         0, 'Dummy sensor'
     )
-    await hass.async_block_till_done()
-    await asyncio.sleep(0)  # Allow state update to propagate
+    await allow_callbacks_to_complete(hass)
 
     # Verify sensor state reflects the low battery status
     sensor_state = hass_get_state_by_unique_id(
@@ -190,13 +190,12 @@ async def test_tamper_callback(
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     # Allow Home Assistant to process the setup
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     await mock_g90alarm.return_value.on_alarm(
         0, 'Dummy sensor', is_tampered=True
     )
-    await hass.async_block_till_done()
-    await asyncio.sleep(0)  # Allow state update to propagate
+    await allow_callbacks_to_complete(hass)
 
     # Verify sensor state reflects the low battery status
     sensor_state = hass_get_state_by_unique_id(
@@ -224,13 +223,12 @@ async def test_door_open_when_arming_callback(
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     # Allow Home Assistant to process the setup
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     await mock_g90alarm.return_value.on_door_open_when_arming(
         0, 'Dummy sensor'
     )
-    await hass.async_block_till_done()
-    await asyncio.sleep(0)  # Allow state update to propagate
+    await allow_callbacks_to_complete(hass)
 
     # Verify sensor state reflects the low battery status
     sensor_state = hass_get_state_by_unique_id(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.device_registry as dr
 from pyg90alarm import G90Error
 
 from custom_components.gs_alarm.const import DOMAIN
-from .conftest import AlarmMockT
+from .conftest import AlarmMockT, allow_callbacks_to_complete
 
 
 @pytest.mark.parametrize("sia_supported", [
@@ -60,7 +60,7 @@ async def test_diagnostics(
     await hass.config_entries.async_setup(config_entry.entry_id)
     # Add `diagnostics` integration
     await async_setup_component(hass, "diagnostics", {})
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     integration_devices = dr.async_entries_for_config_entry(
         dr.async_get(hass), config_entry.entry_id
@@ -126,7 +126,7 @@ async def test_diagnostics_exception(
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await async_setup_component(hass, "diagnostics", {})
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Simulate exception raised from `G90Alarm.history()`
     mock_g90alarm.return_value.history.side_effect = G90Error()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -33,7 +33,8 @@ from homeassistant.components.switch.const import (
 from pyg90alarm import G90TimeoutError, G90Error
 from custom_components.gs_alarm.const import DOMAIN
 from .conftest import (
-    AlarmMockT, hass_get_entity_id_by_unique_id, hass_get_state_by_unique_id
+    AlarmMockT, hass_get_entity_id_by_unique_id, hass_get_state_by_unique_id,
+    allow_callbacks_to_complete,
 )
 
 
@@ -81,7 +82,7 @@ async def test_setup_entry_exception(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify the entity is in expected state
     assert config_entry.state == expected_entry_state
@@ -111,7 +112,7 @@ async def test_alarm_panel_state_update_exception(
     # Simulate some time has passed for HomeAssistant to invoke
     # update for components
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify the panel's state is unknown
     panel_state = hass_get_state_by_unique_id(
@@ -151,7 +152,7 @@ async def test_alarm_panel_service_exception(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'alarm_control_panel', 'dummy_guid'
@@ -202,7 +203,7 @@ async def test_switch_service_exception(
 
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Has to come after entries setup, otherwise `get_devices()` below
     # will trigger callbacks too early

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,7 +19,8 @@ from homeassistant.util import dt
 
 from custom_components.gs_alarm.const import DOMAIN
 from .conftest import (
-    AlarmMockT, hass_get_state_by_unique_id, entry_ids_for_integration_devices
+    AlarmMockT, hass_get_state_by_unique_id, entry_ids_for_integration_devices,
+    allow_callbacks_to_complete,
 )
 
 
@@ -93,7 +94,7 @@ async def test_setup_unload_and_reload_entry_afresh(
     # Simulate some time has passed for HomeAssistant to invoke
     # update for components
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     assert config_entry.title == 'Dummy GUID'
 
@@ -553,7 +554,7 @@ async def test_setup_unload_and_reload_entry_afresh(
 
     # Unload the integration
     await hass.config_entries.async_unload(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
 
 async def test_setup_set_cloud_server_address_not_called(
@@ -577,6 +578,6 @@ async def test_setup_set_cloud_server_address_not_called(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     mock_g90alarm.return_value.set_cloud_server_address.assert_not_called()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -25,7 +25,9 @@ from homeassistant.components.number.const import (
 from pyg90alarm import G90Error
 
 from custom_components.gs_alarm.const import DOMAIN
-from .conftest import AlarmMockT, hass_get_entity_id_by_unique_id
+from .conftest import (
+    AlarmMockT, hass_get_entity_id_by_unique_id, allow_callbacks_to_complete,
+)
 
 
 @pytest.mark.parametrize(
@@ -84,7 +86,7 @@ class TestHostConfigNumberEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         entity_id = hass_get_entity_id_by_unique_id(hass, 'number', unique_id)
 
@@ -99,7 +101,7 @@ class TestHostConfigNumberEntities:
             {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
             blocking=True,
         )
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify save was called
         (await mock_g90alarm.return_value.host_config()).save.assert_called()
@@ -125,7 +127,7 @@ class TestHostConfigNumberEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Simulate data update
         setattr(await mock_g90alarm.return_value.host_config(), field, value)
@@ -133,7 +135,7 @@ class TestHostConfigNumberEntities:
         # Simulate some time has passed for HomeAssistant to invoke
         # update for coordinators and entities
         async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify the entity state was updated correctly
         entity_id = hass_get_entity_id_by_unique_id(hass, 'number', unique_id)
@@ -160,7 +162,7 @@ async def test_host_config_number_exception(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'number', 'dummy_guid_alarm_siren_duration'
@@ -173,7 +175,7 @@ async def test_host_config_number_exception(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 120},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called despite exception
     (await mock_g90alarm.return_value.host_config()).save.assert_called()
@@ -198,7 +200,7 @@ async def test_sia_config_number_entities(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(hass, 'number', unique_id)
     assert entity_id is not None
@@ -210,7 +212,7 @@ async def test_sia_config_number_entities(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called
     (await mock_g90alarm.return_value.sia_config()).save.assert_called()

--- a/tests/test_option_flow.py
+++ b/tests/test_option_flow.py
@@ -19,7 +19,7 @@ from custom_components.gs_alarm.const import (
     CONF_OPT_NOTIFICATIONS_CLOUD,
     CONF_OPT_NOTIFICATIONS_CLOUD_UPSTREAM
 )
-from .conftest import AlarmMockT
+from .conftest import AlarmMockT, allow_callbacks_to_complete
 
 
 @pytest.mark.parametrize(
@@ -120,7 +120,7 @@ async def test_config_flow_options_notifications_protocol(
 
     # Verify it creates entry
     assert result['type'] == FlowResultType.CREATE_ENTRY
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Since the test simulates initial component setup with no options
     # persisted, the `use_local_notifications()` method will be called

--- a/tests/test_register_delete.py
+++ b/tests/test_register_delete.py
@@ -40,6 +40,7 @@ from .conftest import (
     hass_get_state_by_unique_id,
     entry_ids_for_integration_devices,
     AlarmMockT,
+    allow_callbacks_to_complete,
 )
 
 
@@ -93,7 +94,7 @@ async def test_delete(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'button', unique_id
@@ -177,7 +178,7 @@ async def test_register(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'button', register_unique_id
@@ -212,7 +213,7 @@ async def test_register(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     getattr(mock_g90alarm.return_value, expected_call).assert_called_once_with(
         new_type, new_name

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -29,7 +29,9 @@ from pyg90alarm import (
 )
 
 from custom_components.gs_alarm.const import DOMAIN
-from .conftest import AlarmMockT, hass_get_entity_id_by_unique_id
+from .conftest import (
+    AlarmMockT, hass_get_entity_id_by_unique_id, allow_callbacks_to_complete,
+)
 
 
 @pytest.mark.parametrize(
@@ -73,7 +75,7 @@ async def test_sensor_alert_modes(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(hass, 'select', unique_id)
 
@@ -104,7 +106,7 @@ async def test_sensor_alert_modes_exception(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     sensor = (await mock_g90alarm.return_value.get_sensors())[0]
     # Simulate an exception when setting the sensor alert mode
@@ -178,7 +180,7 @@ class TestNetConfigSelectEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         entity_id = hass_get_entity_id_by_unique_id(hass, 'select', unique_id)
 
@@ -189,7 +191,7 @@ class TestNetConfigSelectEntities:
             {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: option},
             blocking=True,
         )
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify save was called
         (await mock_g90alarm.return_value.net_config()).save.assert_called()
@@ -215,7 +217,7 @@ class TestNetConfigSelectEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Simulate data update
         cfg = await mock_g90alarm.return_value.net_config()
@@ -224,7 +226,7 @@ class TestNetConfigSelectEntities:
         # Simulate some time has passed for HomeAssistant to invoke
         # update for coordinators and entities
         async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify the entity state was updated correctly
         entity_id = hass_get_entity_id_by_unique_id(hass, 'select', unique_id)
@@ -300,7 +302,7 @@ class TestHostConfigSelectEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         entity_id = hass_get_entity_id_by_unique_id(hass, 'select', unique_id)
 
@@ -311,7 +313,7 @@ class TestHostConfigSelectEntities:
             {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: option},
             blocking=True,
         )
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify save was called
         (await mock_g90alarm.return_value.host_config()).save.assert_called()
@@ -338,7 +340,7 @@ class TestHostConfigSelectEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Simulate data update
         setattr(await mock_g90alarm.return_value.host_config(), field, value)
@@ -346,7 +348,7 @@ class TestHostConfigSelectEntities:
         # Simulate some time has passed for HomeAssistant to invoke
         # update for coordinators and entities
         async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify the entity state was updated correctly
         entity_id = hass_get_entity_id_by_unique_id(hass, 'select', unique_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,7 +17,9 @@ from custom_components.gs_alarm.const import (
     NOTIFICATIONS_PROTOCOL_SENSOR_LAST_DEVICE_TIMESTAMP_ATTR,
     NOTIFICATIONS_PROTOCOL_SENSOR_LAST_UPSTREAM_TIMESTAMP_ATTR,
 )
-from .conftest import AlarmMockT, hass_get_state_by_unique_id
+from .conftest import (
+    AlarmMockT, hass_get_state_by_unique_id, allow_callbacks_to_complete,
+)
 
 
 async def test_notifications_protocol_binary_sensor(
@@ -34,7 +36,7 @@ async def test_notifications_protocol_binary_sensor(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify the sensor is initially off, has extra attributes with no
     # timestamps
@@ -73,7 +75,7 @@ async def test_notifications_protocol_binary_sensor(
     )
     # Simulate a time change event, which should trigger the sensor update
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=31))
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify the sensor is now on, with the correct timestamps
     sensor_state = hass_get_state_by_unique_id(
@@ -99,7 +101,7 @@ async def test_notifications_protocol_binary_sensor(
     mock_g90alarm.return_value.last_upstream_packet_time = dt.utcnow()
     # Simulate a time change event, which should trigger the sensor update
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=31))
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify the sensor went off
     sensor_state = hass_get_state_by_unique_id(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -33,7 +33,9 @@ from pyg90alarm import (
 )
 
 from custom_components.gs_alarm.const import DOMAIN
-from .conftest import AlarmMockT, hass_get_entity_id_by_unique_id
+from .conftest import (
+    AlarmMockT, hass_get_entity_id_by_unique_id, allow_callbacks_to_complete,
+)
 
 
 @pytest.mark.parametrize(
@@ -108,7 +110,7 @@ async def test_sensor_flags(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'switch', unique_id
@@ -144,7 +146,7 @@ async def test_sensor_flags_exception(
     # Simulate some time has passed for HomeAssistant to invoke
     # update for components
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Simulate an exception when setting the sensor flag
     sensor = (await mock_g90alarm.return_value.get_sensors())[0]
@@ -329,7 +331,7 @@ async def test_config_flags(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'switch', unique_id
@@ -414,7 +416,7 @@ async def test_config_flags_exception(
     # Simulate some time has passed for HomeAssistant to invoke
     # update for components
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'switch', unique_id
@@ -506,7 +508,7 @@ async def test_device(
     # Simulate some time has passed for HomeAssistant to invoke
     # update for components
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'switch', unique_id
@@ -670,7 +672,7 @@ class TestNetConfigSwitchEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         entity_id = hass_get_entity_id_by_unique_id(hass, 'switch', unique_id)
 
@@ -681,7 +683,7 @@ class TestNetConfigSwitchEntities:
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify save was called
         (await mock_g90alarm.return_value.net_config()).save.assert_called()
@@ -709,7 +711,7 @@ class TestNetConfigSwitchEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Simulate data update
         setattr(await mock_g90alarm.return_value.net_config(), field, value)
@@ -717,7 +719,7 @@ class TestNetConfigSwitchEntities:
         # Simulate some time has passed for HomeAssistant to invoke
         # update for coordinators and entities
         async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify the entity state was updated correctly
         entity_id = hass_get_entity_id_by_unique_id(hass, 'switch', unique_id)
@@ -744,7 +746,7 @@ async def test_net_config_switch_exception(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'switch', 'dummy_guid_ap_enabled'
@@ -757,7 +759,7 @@ async def test_net_config_switch_exception(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called despite exception
     (await mock_g90alarm.return_value.net_config()).save.assert_called()
@@ -777,7 +779,7 @@ async def test_reboot_switch(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'switch', 'dummy_guid_reboot'
@@ -847,7 +849,7 @@ async def test_sia_config_switch_entities(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(hass, 'switch', unique_id)
 
@@ -858,7 +860,7 @@ async def test_sia_config_switch_entities(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called
     (await mock_g90alarm.return_value.sia_config()).save.assert_called()
@@ -894,7 +896,7 @@ async def test_cid_config_switch_entities(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(hass, 'switch', unique_id)
 
@@ -905,7 +907,7 @@ async def test_cid_config_switch_entities(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called
     (await mock_g90alarm.return_value.cid_config()).save.assert_called()
@@ -929,7 +931,7 @@ async def test_reboot_switch_not_affected_by_coordinator_timeout(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'switch', 'dummy_guid_reboot'
@@ -945,7 +947,7 @@ async def test_reboot_switch_not_affected_by_coordinator_timeout(
         "simulated timeout"
     )
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify the entity is still available and is OFF
     state = hass.states.get(entity_id)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -29,6 +29,7 @@ from .conftest import (
     AlarmMockT,
     hass_get_entity_id_by_unique_id,
     entry_ids_for_integration_devices,
+    allow_callbacks_to_complete,
 )
 
 
@@ -69,7 +70,7 @@ async def test_net_config_text_entities(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(hass, 'text', unique_id)
 
@@ -80,7 +81,7 @@ async def test_net_config_text_entities(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called
     (await mock_g90alarm.return_value.net_config()).save.assert_called()
@@ -166,7 +167,7 @@ class TestAlarmPhonesTextEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         entity_id = hass_get_entity_id_by_unique_id(hass, 'text', unique_id)
 
@@ -177,7 +178,7 @@ class TestAlarmPhonesTextEntities:
             {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
             blocking=True,
         )
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify save was called
         (await mock_g90alarm.return_value.alarm_phones()).save.assert_called()
@@ -203,7 +204,7 @@ class TestAlarmPhonesTextEntities:
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Simulate data update
         setattr(await mock_g90alarm.return_value.alarm_phones(), field, value)
@@ -211,7 +212,7 @@ class TestAlarmPhonesTextEntities:
         # Simulate some time has passed for HomeAssistant to invoke
         # update for coordinators and entities
         async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
-        await hass.async_block_till_done()
+        await allow_callbacks_to_complete(hass)
 
         # Verify the entity state was updated correctly
         entity_id = hass_get_entity_id_by_unique_id(hass, 'text', unique_id)
@@ -238,7 +239,7 @@ async def test_alarm_phones_text_exception(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(
         hass, 'text', 'dummy_guid_panel_password'
@@ -251,7 +252,7 @@ async def test_alarm_phones_text_exception(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: "test"},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called despite exception
     (await mock_g90alarm.return_value.alarm_phones()).save.assert_called()
@@ -294,7 +295,7 @@ async def test_sia_config_text_entities(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(hass, 'text', unique_id)
     # Set the value
@@ -304,7 +305,7 @@ async def test_sia_config_text_entities(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called
     (await mock_g90alarm.return_value.sia_config()).save.assert_called()
@@ -343,7 +344,7 @@ async def test_cid_config_text_entities(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     entity_id = hass_get_entity_id_by_unique_id(hass, 'text', unique_id)
     # Set the value
@@ -353,7 +354,7 @@ async def test_cid_config_text_entities(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify save was called
     (await mock_g90alarm.return_value.cid_config()).save.assert_called()
@@ -429,7 +430,7 @@ async def test_rename_text_entities(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Find the alarm entity (sensor or device) to rename
     alarm_entity = next(
@@ -451,7 +452,7 @@ async def test_rename_text_entities(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: new_name},
         blocking=True,
     )
-    await hass.async_block_till_done()
+    await allow_callbacks_to_complete(hass)
 
     # Verify the entity name has been changed if requested
     new_entity_name = new_name if expect_name_change else old_name


### PR DESCRIPTION
Observed mostly in CI the tests have become flaky somewhat recently, and is presumably connected with `pyg90alarm` callbacks not given sufficient time to propagate.
The fix is to call `asyncio.sleep(0)` after waiting for HASS tasks to complete - the `sleep` should give non-HASS async tasks a chance to complete, w/o/ explicitly tracking those. To consolidate the change, `allow_callbacks_to_complete()` function has been introduced.