### PR TITLE
chore: Unpin `pytest-unordered` version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 flake8==7.3.0
 pylint==4.0.6
 pytest-homeassistant-custom-component==0.13.339
-pytest-unordered==0.7.0
 mypy[reports]==2.1.0
 pyg90alarm==2.13.2
 # These are pinned by `pytest-homeassistant-custom-component` package
@@ -9,3 +8,4 @@ pytest
 pytest-cov
 coverage
 pylint-per-file-ignores
+pytest-unordered


### PR DESCRIPTION
* `requirements_dev.txt`: Remove version pinning from `pytest-unordered` as it is handled by `pytest-homeassistant-custom-component`